### PR TITLE
autograd + training fixes for cross-queue race condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           pip install pre-commit
 
       - name: Cache pre-commit
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -65,7 +65,7 @@ jobs:
           xcode-select -p || echo "xcode-select not working"
 
       - name: Cache Swift Package Manager
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         with:
           path: |
             .build
@@ -115,7 +115,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip packages
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt', '**/setup.py') }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,12 +64,14 @@ MFA_DEBUG=1 swift test
 ## Known issues
 
 ### MPS cross-queue synchronization
+
 `torch.mps.synchronize()` is required before any UMFA kernel dispatch when
 tensors have pending producer ops on PyTorch's MPS command queue. This is
 handled in `call_swift_flash_attention_impl` (entry-point sync) and after
 `.contiguous()` calls. The SimpleTuner wrapper also does a pre-dispatch sync.
 
 ### MSL 3.2 requirement for bfloat
+
 `torch.mps` lowers the Metal device's default language version, which
 disables `__HAVE_BFLOAT__`. All `device.makeLibrary` calls must use
 `languageVersion = .version3_2`. The `mfaCompileOptions()` helper in
@@ -77,10 +79,13 @@ disables `__HAVE_BFLOAT__`. All `device.makeLibrary` calls must use
 enforce this.
 
 ### Multi-head buffer binding contract
+
 The generated kernel (`AttentionKernel.createBufferBindings`) expects:
+
 ```
 Q@0 K@1 V@2 O@3 L@4  [nil strides]@5-7  num_heads@8-11  mask@12
 ```
+
 The dispatch (`dispatchBatched` in `MultiHeadAttention.swift`) must bind
 exactly this layout. Nil strides @5-7 force the contiguous-BHSD fallback
 offset math.
@@ -88,30 +93,34 @@ offset math.
 ## Quantized attention subsystem
 
 ### What works
+
 - **INT8/INT4 forward** (per-tensor + blockwise) — dequantize-on-load via
   `load_quantized_int8/int4` in `GEMMHeaders.swift`.
-- **INT8 backward** (per-tensor only) — uses the same flash-attention backward
-  kernel with dequantize-on-load.
+- **INT8 backward** (per-tensor + blockwise) — uses the same flash-attention
+  backward kernel with dequantize-on-load. `getOrCreateCorePipeline` sets
+  `HAS_BLOCKWISE_*` function constants from actual operand properties.
+- **Blockwise GEMM compensation** — `createRowSumComputation()` and
+  `createBlockwiseCompensation()` in `AttentionKernel+Accumulate.swift`
+  track per-block quantized sums and apply zero-point correction. The
+  compensation formula is validated in `BlockwiseCompensationTest.swift`.
 - **Fused GPU runtime quantization** — `GEMMBlockwiseQuantization.metal` computes
   block stats + quantizes in one pass via simdgroup reductions.
+- **STE for quantization rounding** — handled at the C++ autograd level
+  (`MetalFlashAttentionFn` in `metal_sdpa_backend.cpp`): forward fake-quants
+  Q/K/V, backward passes gradients straight through the rounding step.
 
 ### What's incomplete
-- **Blockwise backward** — `getOrCreateCorePipeline` hardcodes
-  `HAS_BLOCKWISE_*=false, BLOCK_SIZE_K=1` in backward. Blockwise buffers are
-  plumbed through the FFI but silently degraded to per-tensor.
-- **Blockwise GEMM compensation** — `createRowSumComputation()` and
-  `createBlockwiseCompensation()` in `AttentionKernel+Accumulate.swift` are
-  empty stubs. The math is validated in `BlockwiseCompensationTest.swift`
-  but not wired into the kernel.
-- **STE backward generators** — `generateQuantizedBackwardQueryKernel` /
-  `generateQuantizedBackwardKeyValueKernel` (lines 1428–1685 of
-  `QuantizedAttention.swift`) implement a naive non-flash backward with
-  straight-through estimator + soft clipping. They are defined but never
-  called — the actual backward uses the core flash kernel path.
+
+- **Blockwise backward with non-aligned blocks** — `getOrCreateCorePipeline`
+  now accepts `hasBlockwiseQ/K/V` + `blockSizeK` and sets the function
+  constants correctly. The dequantize-on-load path handles per-block
+  scales when `BLOCK_SIZE_K` is a multiple of 8 (the simdgroup tile width).
+  Non-aligned block sizes are not yet compensated in backward.
 - **Strategy field in backward FFI** — always hardcoded `.legacy`;
   asymmetric/symmetric distinction is lost at the Swift↔FFI boundary.
 
 ### Quantized attention data flow
+
 ```
 FP32/FP16/BF16 input → [runtime quantize or CPU fallback]
   → QuantizedTensor (INT8/INT4 MTLBuffer + scales/zero-points)
@@ -122,17 +131,21 @@ FP32/FP16/BF16 input → [runtime quantize or CPU fallback]
 ```
 
 ### Buffer layout manifest
+
 `QuantizedKernelLayoutManifest` defines static buffer slots (0–30, Metal limit).
 The core flash kernel path uses `AttentionKernel.createBufferBindings()` which
 has its own independent scheme. These two systems must be kept in sync when
 adding new buffer slots.
 
 ### ConvRot (Hadamard rotation)
+
 `HadamardRotation.swift` implements the Fast Walsh-Hadamard Transform on Metal
 for outlier smoothing before quantization. Usage:
+
 ```python
 ext.hadamard_rotate(tensor, block_size=256)  # in-place, tensor on MPS
 ```
+
 Double application = identity (normalized by 1/sqrt(N)).
 
 ## Git workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,144 @@
+# AGENTS.md
+
+## Repository: universal-metal-flash-attention
+
+Universal Metal Flash Attention (UMFA) — a Swift/Metal flash-attention library
+with a PyTorch custom-op FFI for Apple Silicon.
+
+## Architecture
+
+```
+Python (metal_sdpa_extension)
+  → C++ (metal_sdpa_backend.cpp, mla_wrappers.cpp)
+    → Swift FFI (MFABridge.swift — @_cdecl functions)
+      → FlashAttention module (submodule: metal-flash-attention)
+        → AttentionKernel (code-generated Metal source)
+        → MultiHeadAttention (multi-head dispatch)
+        → QuantizedAttention (INT8/INT4 dequantize-on-load)
+```
+
+The `metal-flash-attention` directory is a git submodule pointing at
+`github.com/bghira/metal-flash-attention-plus`.
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `Sources/MFABridge/MFABridge.swift` | All `@_cdecl` FFI functions: forward, backward, MLA, Hadamard rotation |
+| `Sources/MFAFFI/include/mfa_ffi.h` | C header declaring the FFI ABI |
+| `examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp` | C++ backend: tensor binding, layout conversion, autograd (`MetalFlashAttentionFn`) |
+| `examples/pytorch-custom-op-ffi/src/python_bindings.cpp` | pybind11 module definition |
+| `metal-flash-attention/.../QuantizedAttention.swift` | Quantized attention: forward, backward, runtime quantization |
+| `metal-flash-attention/.../MultiHeadAttention.swift` | Multi-head dispatch: forward, backward, pipeline cache |
+| `metal-flash-attention/.../AttentionKernel+Source.swift` | Code-generated Metal kernel source (all kernel types) |
+| `metal-flash-attention/.../AttentionKernel+Accumulate.swift` | Outer-product accumulate loop with blockwise dequantize-on-load |
+| `metal-flash-attention/.../GEMMHeaders.swift` | Metal header: simdgroup storage, load_quantized_int8/int4, buffer bindings |
+| `metal-flash-attention/.../HadamardRotation.swift` | ConvRot-style FWHT kernel for outlier smoothing |
+
+## Build
+
+```bash
+# Swift package (libMFAFFI.dylib)
+swift build -c release
+
+# Python extension (.so)
+cd examples/pytorch-custom-op-ffi
+python setup.py build_ext --inplace
+
+# Run tests
+swift test -c release --filter MLAMFAUsageExample
+python -m pytest tests/ -m "not gpu and not slow"
+```
+
+Requires: macOS 15+, Xcode 16+, torch >= 2.12 (unified memory).
+
+## Debug
+
+Set `MFA_DEBUG=1` to enable verbose diagnostic prints in `QuantizedAttention`
+(buffer sizes, conversion samples, quantization fallback warnings).
+
+```bash
+MFA_DEBUG=1 swift test
+```
+
+## Known issues
+
+### MPS cross-queue synchronization
+`torch.mps.synchronize()` is required before any UMFA kernel dispatch when
+tensors have pending producer ops on PyTorch's MPS command queue. This is
+handled in `call_swift_flash_attention_impl` (entry-point sync) and after
+`.contiguous()` calls. The SimpleTuner wrapper also does a pre-dispatch sync.
+
+### MSL 3.2 requirement for bfloat
+`torch.mps` lowers the Metal device's default language version, which
+disables `__HAVE_BFLOAT__`. All `device.makeLibrary` calls must use
+`languageVersion = .version3_2`. The `mfaCompileOptions()` helper in
+`MFABridge.swift` and the inline options in `MultiHeadAttention.swift`
+enforce this.
+
+### Multi-head buffer binding contract
+The generated kernel (`AttentionKernel.createBufferBindings`) expects:
+```
+Q@0 K@1 V@2 O@3 L@4  [nil strides]@5-7  num_heads@8-11  mask@12
+```
+The dispatch (`dispatchBatched` in `MultiHeadAttention.swift`) must bind
+exactly this layout. Nil strides @5-7 force the contiguous-BHSD fallback
+offset math.
+
+## Quantized attention subsystem
+
+### What works
+- **INT8/INT4 forward** (per-tensor + blockwise) — dequantize-on-load via
+  `load_quantized_int8/int4` in `GEMMHeaders.swift`.
+- **INT8 backward** (per-tensor only) — uses the same flash-attention backward
+  kernel with dequantize-on-load.
+- **Fused GPU runtime quantization** — `GEMMBlockwiseQuantization.metal` computes
+  block stats + quantizes in one pass via simdgroup reductions.
+
+### What's incomplete
+- **Blockwise backward** — `getOrCreateCorePipeline` hardcodes
+  `HAS_BLOCKWISE_*=false, BLOCK_SIZE_K=1` in backward. Blockwise buffers are
+  plumbed through the FFI but silently degraded to per-tensor.
+- **Blockwise GEMM compensation** — `createRowSumComputation()` and
+  `createBlockwiseCompensation()` in `AttentionKernel+Accumulate.swift` are
+  empty stubs. The math is validated in `BlockwiseCompensationTest.swift`
+  but not wired into the kernel.
+- **STE backward generators** — `generateQuantizedBackwardQueryKernel` /
+  `generateQuantizedBackwardKeyValueKernel` (lines 1428–1685 of
+  `QuantizedAttention.swift`) implement a naive non-flash backward with
+  straight-through estimator + soft clipping. They are defined but never
+  called — the actual backward uses the core flash kernel path.
+- **Strategy field in backward FFI** — always hardcoded `.legacy`;
+  asymmetric/symmetric distinction is lost at the Swift↔FFI boundary.
+
+### Quantized attention data flow
+```
+FP32/FP16/BF16 input → [runtime quantize or CPU fallback]
+  → QuantizedTensor (INT8/INT4 MTLBuffer + scales/zero-points)
+    → AttentionKernel.createSource() (code-generated MSL with function constants)
+      → load_quantized_int8/int4 (dequantize-on-load into FP32 simdgroup tiles)
+        → FP32 flash-attention math
+          → FP32 output buffer
+```
+
+### Buffer layout manifest
+`QuantizedKernelLayoutManifest` defines static buffer slots (0–30, Metal limit).
+The core flash kernel path uses `AttentionKernel.createBufferBindings()` which
+has its own independent scheme. These two systems must be kept in sync when
+adding new buffer slots.
+
+### ConvRot (Hadamard rotation)
+`HadamardRotation.swift` implements the Fast Walsh-Hadamard Transform on Metal
+for outlier smoothing before quantization. Usage:
+```python
+ext.hadamard_rotate(tensor, block_size=256)  # in-place, tensor on MPS
+```
+Double application = identity (normalized by 1/sqrt(N)).
+
+## Git workflow
+
+- Submodule changes go to `metal-flash-attention` (mfa+ repo) first, then
+  the universal repo records the new submodule pointer.
+- Always push the submodule before the superproject.
+- CI runs on macos-15 runners (virtualized M1, 7 GiB). Mark memory-heavy
+  tests `@pytest.mark.slow` and GPU-only tests `@pytest.mark.gpu`.

--- a/Sources/MFABridge/MFABridge+Quantized.swift
+++ b/Sources/MFABridge/MFABridge+Quantized.swift
@@ -211,8 +211,309 @@ public func mfa_multihead_attention_quantized_direct(
     0, 0, // qScale, qZeroPoint - not used
     0, 0, // kScale, kZeroPoint - not used
     0, 0, // vScale, vZeroPoint - not used
-    qPrecision, kPrecision, vPrecision,
-    2, // outputPrecision = FP32
-    false, false, false, false // no transpose
+     qPrecision, kPrecision, vPrecision,
+     2, // outputPrecision = FP32
+     false, false, false, false // no transpose
+   )
+}
+
+// MARK: - Multi-Head Quantized Attention with Autograd Support
+
+/// Forward pass with runtime INT8 quantization + LSE output for autograd.
+///
+/// Quantizes Q/K/V to INT8 (per-tensor), then dispatches the quantized flash
+/// attention kernel per head. Writes both the attention output and the
+/// logsumexp buffer needed by the backward pass.
+@_cdecl("mfa_quantized_forward_with_lse")
+public func mfa_quantized_forward_with_lse(
+  _ context: UnsafeMutableRawPointer?,
+  _ q: UnsafeMutableRawPointer?,
+  _ k: UnsafeMutableRawPointer?,
+  _ v: UnsafeMutableRawPointer?,
+  _ out: UnsafeMutableRawPointer?,
+  _ lse: UnsafeMutableRawPointer?,
+  _ batchSize: UInt32,
+  _ seqLenQ: UInt32,
+  _ seqLenKV: UInt32,
+  _ numHeads: UInt32,
+  _ headDim: UInt16,
+  _ softmaxScale: Float,
+  _ causal: Bool,
+  _ targetPrecision: Int32,
+  _ quantMode: Int32
+)
+  -> Int32
+{
+  guard
+    let context,
+    let q, let k, let v, let out, let lse
+  else {
+    return 1
+  }
+
+  let mfaContext = Unmanaged<MFAContext>.fromOpaque(context).takeUnretainedValue()
+  let device = mfaContext.device
+
+  let qBuffer = Unmanaged<MFABuffer>.fromOpaque(q).takeUnretainedValue()
+  let kBuffer = Unmanaged<MFABuffer>.fromOpaque(k).takeUnretainedValue()
+  let vBuffer = Unmanaged<MFABuffer>.fromOpaque(v).takeUnretainedValue()
+  let outBuffer = Unmanaged<MFABuffer>.fromOpaque(out).takeUnretainedValue()
+  let lseBuffer = Unmanaged<MFABuffer>.fromOpaque(lse).takeUnretainedValue()
+
+  let precision = GEMMOperandPrecision(rawValue: UInt16(targetPrecision)) ?? .INT8
+  let mode: QuantizationMode = switch quantMode {
+  case 0: .tensorWise
+  case 2: .blockwise(blockSizeK: 64)
+  default: .tensorWise
+  }
+
+  let quantAttention = QuantizedAttention(device: device)
+
+  let fullQShape = [Int(batchSize), Int(numHeads), Int(seqLenQ), Int(headDim)]
+  let fullKVShape = [Int(batchSize), Int(numHeads), Int(seqLenKV), Int(headDim)]
+
+  guard
+    let qTensor = quantAttention.createQuantizedTensorFromBufferPublic(
+      buffer: qBuffer.buffer, shape: fullQShape,
+      inputPrecision: .FP32, targetPrecision: precision,
+      quantizationMode: mode, targetStrategy: .legacy
+    ),
+    let kTensor = quantAttention.createQuantizedTensorFromBufferPublic(
+      buffer: kBuffer.buffer, shape: fullKVShape,
+      inputPrecision: .FP32, targetPrecision: precision,
+      quantizationMode: mode, targetStrategy: .legacy
+    ),
+    let vTensor = quantAttention.createQuantizedTensorFromBufferPublic(
+      buffer: vBuffer.buffer, shape: fullKVShape,
+      inputPrecision: .FP32, targetPrecision: precision,
+      quantizationMode: mode, targetStrategy: .legacy
+    )
+  else {
+    return 5
+  }
+
+  var baseDescriptor = AttentionDescriptor()
+  baseDescriptor.matrixDimensions = (
+    row: seqLenQ, column: seqLenKV, head: headDim
   )
+  baseDescriptor.transposeState = (Q: false, K: false, V: false, O: false)
+  baseDescriptor.softmaxScale = softmaxScale
+  baseDescriptor.sparsityPattern = causal ? .causal : .none
+
+  var quantConfig = QuantizedAttention.Configuration()
+  quantConfig.queryPrecision = qTensor.parameters.precision
+  quantConfig.keyPrecision = kTensor.parameters.precision
+  quantConfig.valuePrecision = vTensor.parameters.precision
+
+  let quantDescriptor = QuantizedAttention.QuantizedAttentionDescriptor(
+    baseDescriptor: baseDescriptor, quantizationConfig: quantConfig
+  )
+
+  let quantElemSize = precision.size
+  let fp32Size = MemoryLayout<Float>.stride
+
+  for batchIdx in 0..<Int(batchSize) {
+    for headIdx in 0..<Int(numHeads) {
+      let qOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * Int(headDim) * quantElemSize
+      let kOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenKV) * Int(headDim) * quantElemSize
+      let vOff = kOff
+      let oOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * Int(headDim) * fp32Size
+      let lseOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * fp32Size
+
+      guard
+        let cmd = quantAttention.forward(
+          query: qTensor, key: kTensor, value: vTensor,
+          output: outBuffer.buffer,
+          descriptor: quantDescriptor,
+          bufferOffsets: (q: qOff, k: kOff, v: vOff, o: oOff),
+          externalLogsumexp: lseBuffer.buffer
+        )
+      else {
+        return 5
+      }
+      _ = lseOff
+      cmd.commit()
+      cmd.waitUntilCompleted()
+
+      if let error = cmd.error {
+        print("Quantized forward error (batch \(batchIdx), head \(headIdx)): \(error)")
+        return 5
+      }
+    }
+  }
+
+  return 0
+}
+
+/// Backward pass with runtime INT8 quantization.
+///
+/// Re-quantizes Q/K/V to INT8 (deterministic — same inputs produce same
+/// quantized values as the forward), then dispatches the quantized flash
+/// backward kernels per head. Computes dQ, dK, dV.
+@_cdecl("mfa_quantized_backward")
+public func mfa_quantized_backward(
+  _ context: UnsafeMutableRawPointer?,
+  _ q: UnsafeMutableRawPointer?,
+  _ k: UnsafeMutableRawPointer?,
+  _ v: UnsafeMutableRawPointer?,
+  _ out: UnsafeMutableRawPointer?,
+  _ gradOut: UnsafeMutableRawPointer?,
+  _ lse: UnsafeMutableRawPointer?,
+  _ gradQ: UnsafeMutableRawPointer?,
+  _ gradK: UnsafeMutableRawPointer?,
+  _ gradV: UnsafeMutableRawPointer?,
+  _ batchSize: UInt32,
+  _ seqLenQ: UInt32,
+  _ seqLenKV: UInt32,
+  _ numHeads: UInt32,
+  _ headDim: UInt16,
+  _ softmaxScale: Float,
+  _ causal: Bool,
+  _ targetPrecision: Int32,
+  _ quantMode: Int32
+)
+  -> Int32
+{
+  guard
+    let context,
+    let q, let k, let v, let out,
+    let gradOut, let lse,
+    let gradQ, let gradK, let gradV
+  else {
+    return 1
+  }
+
+  let mfaContext = Unmanaged<MFAContext>.fromOpaque(context).takeUnretainedValue()
+  let device = mfaContext.device
+
+  let qBuffer = Unmanaged<MFABuffer>.fromOpaque(q).takeUnretainedValue()
+  let kBuffer = Unmanaged<MFABuffer>.fromOpaque(k).takeUnretainedValue()
+  let vBuffer = Unmanaged<MFABuffer>.fromOpaque(v).takeUnretainedValue()
+  let outBuffer = Unmanaged<MFABuffer>.fromOpaque(out).takeUnretainedValue()
+  let gradOutBuffer = Unmanaged<MFABuffer>.fromOpaque(gradOut).takeUnretainedValue()
+  let lseBuffer = Unmanaged<MFABuffer>.fromOpaque(lse).takeUnretainedValue()
+  let gradQBuffer = Unmanaged<MFABuffer>.fromOpaque(gradQ).takeUnretainedValue()
+  let gradKBuffer = Unmanaged<MFABuffer>.fromOpaque(gradK).takeUnretainedValue()
+  let gradVBuffer = Unmanaged<MFABuffer>.fromOpaque(gradV).takeUnretainedValue()
+
+  let precision = GEMMOperandPrecision(rawValue: UInt16(targetPrecision)) ?? .INT8
+  let mode: QuantizationMode = switch quantMode {
+  case 0: .tensorWise
+  case 2: .blockwise(blockSizeK: 64)
+  default: .tensorWise
+  }
+
+  let quantAttention = QuantizedAttention(device: device)
+
+  let fullQShape = [Int(batchSize), Int(numHeads), Int(seqLenQ), Int(headDim)]
+  let fullKVShape = [Int(batchSize), Int(numHeads), Int(seqLenKV), Int(headDim)]
+
+  guard
+    let qTensor = quantAttention.createQuantizedTensorFromBufferPublic(
+      buffer: qBuffer.buffer, shape: fullQShape,
+      inputPrecision: .FP32, targetPrecision: precision,
+      quantizationMode: mode, targetStrategy: .legacy
+    ),
+    let kTensor = quantAttention.createQuantizedTensorFromBufferPublic(
+      buffer: kBuffer.buffer, shape: fullKVShape,
+      inputPrecision: .FP32, targetPrecision: precision,
+      quantizationMode: mode, targetStrategy: .legacy
+    ),
+    let vTensor = quantAttention.createQuantizedTensorFromBufferPublic(
+      buffer: vBuffer.buffer, shape: fullKVShape,
+      inputPrecision: .FP32, targetPrecision: precision,
+      quantizationMode: mode, targetStrategy: .legacy
+    )
+  else {
+    return 5
+  }
+
+  var baseDescriptor = AttentionDescriptor()
+  baseDescriptor.matrixDimensions = (
+    row: seqLenQ, column: seqLenKV, head: headDim
+  )
+  baseDescriptor.transposeState = (Q: false, K: false, V: false, O: false)
+  baseDescriptor.softmaxScale = softmaxScale
+  baseDescriptor.sparsityPattern = causal ? .causal : .none
+
+  var quantConfig = QuantizedAttention.Configuration()
+  quantConfig.queryPrecision = qTensor.parameters.precision
+  quantConfig.keyPrecision = kTensor.parameters.precision
+  quantConfig.valuePrecision = vTensor.parameters.precision
+
+  let quantDescriptor = QuantizedAttention.QuantizedAttentionDescriptor(
+    baseDescriptor: baseDescriptor, quantizationConfig: quantConfig
+  )
+
+  let quantElemSize = precision.size
+  let fp32Size = MemoryLayout<Float>.stride
+
+  for batchIdx in 0..<Int(batchSize) {
+    for headIdx in 0..<Int(numHeads) {
+      let qOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * Int(headDim) * quantElemSize
+      let kOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenKV) * Int(headDim) * quantElemSize
+      let vOff = kOff
+      let oOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * Int(headDim) * fp32Size
+      let goOff = oOff
+      let lseOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * fp32Size
+      let gqOff = oOff
+      let gkOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenKV) * Int(headDim) * fp32Size
+      let gvOff = gkOff
+
+      let dBuf = device.makeBuffer(
+        length: Int(seqLenQ) * fp32Size,
+        options: .storageModeShared
+      )!
+
+      guard
+        let cmdBQ = quantAttention.backwardQuery(
+          query: qTensor,
+          key: kTensor,
+          value: vTensor,
+          output: outBuffer.buffer,
+          gradOutput: gradOutBuffer.buffer,
+          logsumexp: lseBuffer.buffer,
+          gradQuery: gradQBuffer.buffer,
+          dValues: dBuf,
+          descriptor: quantDescriptor,
+          bufferOffsets: (q: qOff, k: kOff, v: vOff, o: oOff, go: goOff, lse: lseOff, gq: gqOff, dv: 0)
+        )
+      else {
+        return 5
+      }
+      cmdBQ.commit()
+      cmdBQ.waitUntilCompleted()
+
+      if let error = cmdBQ.error {
+        print("Quantized backwardQuery error: \(error)")
+        return 5
+      }
+
+      guard
+        let cmdBK = quantAttention.backwardKeyValue(
+          query: qTensor,
+          key: kTensor,
+          value: vTensor,
+          gradOutput: gradOutBuffer.buffer,
+          logsumexp: lseBuffer.buffer,
+          dValues: dBuf,
+          gradKey: gradKBuffer.buffer,
+          gradValue: gradVBuffer.buffer,
+          descriptor: quantDescriptor,
+          bufferOffsets: (q: qOff, k: kOff, v: vOff, go: goOff, lse: lseOff, dv: 0, gk: gkOff, gv: gvOff)
+        )
+      else {
+        return 5
+      }
+      cmdBK.commit()
+      cmdBK.waitUntilCompleted()
+
+      if let error = cmdBK.error {
+        print("Quantized backwardKeyValue error: \(error)")
+        return 5
+      }
+    }
+  }
+
+  return 0
 }

--- a/Sources/MFABridge/MFABridge+Quantized.swift
+++ b/Sources/MFABridge/MFABridge+Quantized.swift
@@ -325,13 +325,12 @@ public func mfa_quantized_forward_with_lse(
           query: qTensor, key: kTensor, value: vTensor,
           output: outBuffer.buffer,
           descriptor: quantDescriptor,
-          bufferOffsets: (q: qOff, k: kOff, v: vOff, o: oOff),
+          bufferOffsets: (q: qOff, k: kOff, v: vOff, o: oOff, lse: lseOff),
           externalLogsumexp: lseBuffer.buffer
         )
       else {
         return 5
       }
-      _ = lseOff
       cmd.commit()
       cmd.waitUntilCompleted()
 

--- a/Sources/MFABridge/MFABridge+Quantized.swift
+++ b/Sources/MFABridge/MFABridge+Quantized.swift
@@ -211,10 +211,10 @@ public func mfa_multihead_attention_quantized_direct(
     0, 0, // qScale, qZeroPoint - not used
     0, 0, // kScale, kZeroPoint - not used
     0, 0, // vScale, vZeroPoint - not used
-     qPrecision, kPrecision, vPrecision,
-     2, // outputPrecision = FP32
-     false, false, false, false // no transpose
-   )
+    qPrecision, kPrecision, vPrecision,
+    2, // outputPrecision = FP32
+    false, false, false, false // no transpose
+  )
 }
 
 // MARK: - Multi-Head Quantized Attention with Autograd Support
@@ -475,7 +475,16 @@ public func mfa_quantized_backward(
           gradQuery: gradQBuffer.buffer,
           dValues: dBuf,
           descriptor: quantDescriptor,
-          bufferOffsets: (q: qOff, k: kOff, v: vOff, o: oOff, go: goOff, lse: lseOff, gq: gqOff, dv: 0)
+          bufferOffsets: (
+            q: qOff,
+            k: kOff,
+            v: vOff,
+            o: oOff,
+            go: goOff,
+            lse: lseOff,
+            gq: gqOff,
+            dv: 0
+          )
         )
       else {
         return 5
@@ -499,7 +508,16 @@ public func mfa_quantized_backward(
           gradKey: gradKBuffer.buffer,
           gradValue: gradVBuffer.buffer,
           descriptor: quantDescriptor,
-          bufferOffsets: (q: qOff, k: kOff, v: vOff, go: goOff, lse: lseOff, dv: 0, gk: gkOff, gv: gvOff)
+          bufferOffsets: (
+            q: qOff,
+            k: kOff,
+            v: vOff,
+            go: goOff,
+            lse: lseOff,
+            dv: 0,
+            gk: gkOff,
+            gv: gvOff
+          )
         )
       else {
         return 5

--- a/Sources/MFABridge/MFABridge.swift
+++ b/Sources/MFABridge/MFABridge.swift
@@ -2594,15 +2594,18 @@ public func mfa_attention_forward_with_lse(
 
   let queryShape = MultiHeadShape(
     batchSize: batchSize, numHeads: numHeads,
-    sequenceLength: seqLenQ, headDimension: headDim)
+    sequenceLength: seqLenQ, headDimension: headDim
+  )
   let kvShape = MultiHeadShape(
     batchSize: batchSize, numHeads: numHeads,
-    sequenceLength: seqLenKV, headDimension: headDim)
+    sequenceLength: seqLenKV, headDimension: headDim
+  )
 
   let descriptor = MultiHeadAttentionDescriptor(
     baseDescriptor: baseDescriptor,
     queryShape: queryShape, keyShape: kvShape, valueShape: kvShape,
-    broadcastMode: .standard, dispatchStrategy: .perBatch)
+    broadcastMode: .standard, dispatchStrategy: .perBatch
+  )
 
   guard
     let commandBuffer = multiHeadAttention.forward(
@@ -2661,7 +2664,8 @@ public func mfa_attention_backward(
 )
   -> Int32
 {
-  guard let context,
+  guard
+    let context,
     let dout, let q, let k, let v, let out, let lse,
     let dq, let dk, let dv, let dBuffer
   else {
@@ -2692,15 +2696,18 @@ public func mfa_attention_backward(
 
   let queryShape = MultiHeadShape(
     batchSize: batchSize, numHeads: numHeads,
-    sequenceLength: seqLenQ, headDimension: headDim)
+    sequenceLength: seqLenQ, headDimension: headDim
+  )
   let kvShape = MultiHeadShape(
     batchSize: batchSize, numHeads: numHeads,
-    sequenceLength: seqLenKV, headDimension: headDim)
+    sequenceLength: seqLenKV, headDimension: headDim
+  )
 
   let descriptor = MultiHeadAttentionDescriptor(
     baseDescriptor: baseDescriptor,
     queryShape: queryShape, keyShape: kvShape, valueShape: kvShape,
-    broadcastMode: .standard, dispatchStrategy: .perBatch)
+    broadcastMode: .standard, dispatchStrategy: .perBatch
+  )
 
   // Zero the D scratch buffer (needed by backwardQuery).
   let dCount = Int(batchSize) * Int(numHeads) * Int(seqLenQ)

--- a/Sources/MFABridge/MFABridge.swift
+++ b/Sources/MFABridge/MFABridge.swift
@@ -2882,3 +2882,35 @@ public func mfa_sparse_indexer_scores(
 
   return 0
 }
+
+// MARK: - Hadamard Rotation (ConvRot-style)
+
+/// Apply group-wise Hadamard rotation (FWHT) to a buffer in-place.
+/// Used as an optional outlier-smoothing step before quantized attention.
+@_cdecl("mfa_hadamard_rotate")
+public func mfa_hadamard_rotate(
+  _ data: UnsafeMutableRawPointer?,
+  _ blockSize: UInt32,
+  _ numBlocks: UInt32
+)
+  -> Int32
+{
+  guard let data else { return 1 }
+  guard blockSize > 0, numBlocks > 0 else { return 1 }
+
+  let dev = MTLCreateSystemDefaultDevice()!
+  let rotator = HadamardRotation(device: dev)
+  let buffer = Unmanaged<MFABuffer>.fromOpaque(data).takeUnretainedValue()
+
+  do {
+    _ = try rotator.rotate(
+      buffer: buffer.buffer,
+      blockSize: Int(blockSize),
+      numBlocks: Int(numBlocks)
+    )
+    return 0
+  } catch {
+    print("Hadamard rotation error: \(error)")
+    return 5
+  }
+}

--- a/Sources/MFABridge/MFABridge.swift
+++ b/Sources/MFABridge/MFABridge.swift
@@ -2545,6 +2545,199 @@ public func mfa_mla_forward(
   }
 }
 
+// MARK: - Autograd (Forward with LSE + Backward)
+
+/// Forward pass that also writes the log-sum-exp buffer for autograd.
+/// Same as mfa_attention_forward but the caller provides an LSE output buffer.
+@_cdecl("mfa_attention_forward_with_lse")
+public func mfa_attention_forward_with_lse(
+  _ context: UnsafeMutableRawPointer?,
+  _ q: UnsafeMutableRawPointer?,
+  _ k: UnsafeMutableRawPointer?,
+  _ v: UnsafeMutableRawPointer?,
+  _ out: UnsafeMutableRawPointer?,
+  _ lse: UnsafeMutableRawPointer?,
+  _ batchSize: UInt32,
+  _ seqLenQ: UInt32,
+  _ seqLenKV: UInt32,
+  _ numHeads: UInt32,
+  _ headDim: UInt16,
+  _ softmaxScale: Float,
+  _ causal: Bool,
+  _ transposeQ: Bool,
+  _ transposeK: Bool,
+  _ transposeV: Bool,
+  _ transposeO: Bool
+)
+  -> Int32
+{
+  guard let context, let q, let k, let v, let out, let lse else {
+    return 1
+  }
+
+  let mfaContext = Unmanaged<MFAContext>.fromOpaque(context).takeUnretainedValue()
+  let qBuffer = Unmanaged<MFABuffer>.fromOpaque(q).takeUnretainedValue()
+  let kBuffer = Unmanaged<MFABuffer>.fromOpaque(k).takeUnretainedValue()
+  let vBuffer = Unmanaged<MFABuffer>.fromOpaque(v).takeUnretainedValue()
+  let outBuffer = Unmanaged<MFABuffer>.fromOpaque(out).takeUnretainedValue()
+  let lseBuffer = Unmanaged<MFABuffer>.fromOpaque(lse).takeUnretainedValue()
+
+  let multiHeadAttention = MultiHeadAttention(device: mfaContext.device)
+
+  var baseDescriptor = AttentionDescriptor()
+  baseDescriptor.matrixDimensions = (row: seqLenQ, column: seqLenKV, head: headDim)
+  baseDescriptor.lowPrecisionInputs = false
+  baseDescriptor.lowPrecisionIntermediates = false
+  baseDescriptor.transposeState = (Q: transposeQ, K: transposeK, V: transposeV, O: transposeO)
+  baseDescriptor.sparsityPattern = causal ? .causal : .none
+  baseDescriptor.softmaxScale = softmaxScale
+
+  let queryShape = MultiHeadShape(
+    batchSize: batchSize, numHeads: numHeads,
+    sequenceLength: seqLenQ, headDimension: headDim)
+  let kvShape = MultiHeadShape(
+    batchSize: batchSize, numHeads: numHeads,
+    sequenceLength: seqLenKV, headDimension: headDim)
+
+  let descriptor = MultiHeadAttentionDescriptor(
+    baseDescriptor: baseDescriptor,
+    queryShape: queryShape, keyShape: kvShape, valueShape: kvShape,
+    broadcastMode: .standard, dispatchStrategy: .perBatch)
+
+  guard
+    let commandBuffer = multiHeadAttention.forward(
+      query: qBuffer.buffer,
+      key: kBuffer.buffer,
+      value: vBuffer.buffer,
+      output: outBuffer.buffer,
+      logsumexp: lseBuffer.buffer,
+      descriptor: descriptor,
+      maskBuffer: nil
+    )
+  else {
+    return 5
+  }
+
+  commandBuffer.commit()
+  commandBuffer.waitUntilCompleted()
+
+  if let error = commandBuffer.error {
+    print("Forward-with-LSE error: \(error)")
+    return 5
+  }
+
+  let gpuLatency = commandBuffer.gpuEndTime - commandBuffer.gpuStartTime
+  GlobalContextStore.shared.updateLatency(gpuLatency)
+  return 0
+}
+
+/// Backward pass for flash attention.
+/// Computes dQ, dK, dV given dO, Q, K, V, O, L from the forward pass.
+/// The caller must provide a scratch D buffer of size [B*H*S_q] FP32.
+@_cdecl("mfa_attention_backward")
+public func mfa_attention_backward(
+  _ context: UnsafeMutableRawPointer?,
+  _ dout: UnsafeMutableRawPointer?,
+  _ q: UnsafeMutableRawPointer?,
+  _ k: UnsafeMutableRawPointer?,
+  _ v: UnsafeMutableRawPointer?,
+  _ out: UnsafeMutableRawPointer?,
+  _ lse: UnsafeMutableRawPointer?,
+  _ dq: UnsafeMutableRawPointer?,
+  _ dk: UnsafeMutableRawPointer?,
+  _ dv: UnsafeMutableRawPointer?,
+  _ dBuffer: UnsafeMutableRawPointer?,
+  _ batchSize: UInt32,
+  _ seqLenQ: UInt32,
+  _ seqLenKV: UInt32,
+  _ numHeads: UInt32,
+  _ headDim: UInt16,
+  _ softmaxScale: Float,
+  _ causal: Bool,
+  _ transposeQ: Bool,
+  _ transposeK: Bool,
+  _ transposeV: Bool,
+  _ transposeO: Bool
+)
+  -> Int32
+{
+  guard let context,
+    let dout, let q, let k, let v, let out, let lse,
+    let dq, let dk, let dv, let dBuffer
+  else {
+    return 1
+  }
+
+  let mfaContext = Unmanaged<MFAContext>.fromOpaque(context).takeUnretainedValue()
+  let doutBuf = Unmanaged<MFABuffer>.fromOpaque(dout).takeUnretainedValue()
+  let qBuf = Unmanaged<MFABuffer>.fromOpaque(q).takeUnretainedValue()
+  let kBuf = Unmanaged<MFABuffer>.fromOpaque(k).takeUnretainedValue()
+  let vBuf = Unmanaged<MFABuffer>.fromOpaque(v).takeUnretainedValue()
+  let outBuf = Unmanaged<MFABuffer>.fromOpaque(out).takeUnretainedValue()
+  let lseBuf = Unmanaged<MFABuffer>.fromOpaque(lse).takeUnretainedValue()
+  let dqBuf = Unmanaged<MFABuffer>.fromOpaque(dq).takeUnretainedValue()
+  let dkBuf = Unmanaged<MFABuffer>.fromOpaque(dk).takeUnretainedValue()
+  let dvBuf = Unmanaged<MFABuffer>.fromOpaque(dv).takeUnretainedValue()
+  let dScratchBuf = Unmanaged<MFABuffer>.fromOpaque(dBuffer).takeUnretainedValue()
+
+  let multiHeadAttention = MultiHeadAttention(device: mfaContext.device)
+
+  var baseDescriptor = AttentionDescriptor()
+  baseDescriptor.matrixDimensions = (row: seqLenQ, column: seqLenKV, head: headDim)
+  baseDescriptor.lowPrecisionInputs = false
+  baseDescriptor.lowPrecisionIntermediates = false
+  baseDescriptor.transposeState = (Q: transposeQ, K: transposeK, V: transposeV, O: transposeO)
+  baseDescriptor.sparsityPattern = causal ? .causal : .none
+  baseDescriptor.softmaxScale = softmaxScale
+
+  let queryShape = MultiHeadShape(
+    batchSize: batchSize, numHeads: numHeads,
+    sequenceLength: seqLenQ, headDimension: headDim)
+  let kvShape = MultiHeadShape(
+    batchSize: batchSize, numHeads: numHeads,
+    sequenceLength: seqLenKV, headDimension: headDim)
+
+  let descriptor = MultiHeadAttentionDescriptor(
+    baseDescriptor: baseDescriptor,
+    queryShape: queryShape, keyShape: kvShape, valueShape: kvShape,
+    broadcastMode: .standard, dispatchStrategy: .perBatch)
+
+  // Zero the D scratch buffer (needed by backwardQuery).
+  let dCount = Int(batchSize) * Int(numHeads) * Int(seqLenQ)
+  memset(dScratchBuf.buffer.contents(), 0, dCount * 4)
+
+  guard
+    let commandBuffer = multiHeadAttention.backward(
+      query: qBuf.buffer,
+      key: kBuf.buffer,
+      value: vBuf.buffer,
+      output: outBuf.buffer,
+      dOutput: doutBuf.buffer,
+      logsumexp: lseBuf.buffer,
+      dQuery: dqBuf.buffer,
+      dKey: dkBuf.buffer,
+      dValue: dvBuf.buffer,
+      dBuffer: dScratchBuf.buffer,
+      descriptor: descriptor,
+      maskBuffer: nil
+    )
+  else {
+    return 5
+  }
+
+  commandBuffer.commit()
+  commandBuffer.waitUntilCompleted()
+
+  if let error = commandBuffer.error {
+    print("Backward error: \(error)")
+    return 5
+  }
+
+  let gpuLatency = commandBuffer.gpuEndTime - commandBuffer.gpuStartTime
+  GlobalContextStore.shared.updateLatency(gpuLatency)
+  return 0
+}
+
 // MARK: - Sparse Indexer Operations
 
 @_cdecl("mfa_sparse_indexer_scores")

--- a/Sources/MFABridge/MFABridge.swift
+++ b/Sources/MFABridge/MFABridge.swift
@@ -11,11 +11,11 @@ private extension NSLock {
   }
 }
 
-// Compile options for runtime-compiled Metal kernels. PyTorch's MPS backend
-// (once imported) lowers the device's default Metal language version, which
-// disables `__HAVE_BFLOAT__` and makes generated bfloat kernels fail with
-// "unknown type name 'bfloat'". Pinning MSL 3.2 restores native bfloat and
-// overrides that — verified via the diagnose-runner workflow.
+/// Compile options for runtime-compiled Metal kernels. PyTorch's MPS backend
+/// (once imported) lowers the device's default Metal language version, which
+/// disables `__HAVE_BFLOAT__` and makes generated bfloat kernels fail with
+/// "unknown type name 'bfloat'". Pinning MSL 3.2 restores native bfloat and
+/// overrides that — verified via the diagnose-runner workflow.
 func mfaCompileOptions(mathSafe: Bool = false) -> MTLCompileOptions {
   let options = MTLCompileOptions()
   options.languageVersion = .version3_2
@@ -1018,19 +1018,10 @@ public func mfa_attention_forward(
       // Set custom scale factor - this fixes the root cause of the correctness issue
       descriptor.softmaxScale = softmaxScale
 
-      // Set precision based on input parameters
-      // NOTE: inputPrecision and intermediatePrecision parameters are accepted but not currently
-      // used
-      // IMPORTANT: When using FP16/BF16 precision modes with FP32 data,
-      // we must use FP32 inputs to avoid NaN issues from precision mismatch
-      // The inputs are always FP32 from the FFI layer
+      // Always use FP32 inputs — the C++ backend promotes fp16/bf16 to fp32
+      // before calling the kernel, so the kernel always receives fp32 data.
       descriptor.lowPrecisionInputs = false
-      // Use FP32 intermediates for numerical stability
       descriptor.lowPrecisionIntermediates = false
-
-      // Suppress unused parameter warnings - these are part of the API but not used yet
-      _ = inputPrecision
-      _ = intermediatePrecision
 
       // Create kernel descriptor
       let kernelDescriptor = descriptor.kernelDescriptor(type: .forward)
@@ -1941,8 +1932,8 @@ private func mfa_attention_forward_multihead_internal(
   headDim: UInt16,
   softmaxScale: Float,
   causal: Bool,
-  inputPrecision: Int32,
-  intermediatePrecision: Int32,
+  inputPrecision _: Int32,
+  intermediatePrecision _: Int32,
   transposeQ: Bool,
   transposeK: Bool,
   transposeV: Bool,
@@ -1958,18 +1949,9 @@ private func mfa_attention_forward_multihead_internal(
   var baseDescriptor = AttentionDescriptor()
   baseDescriptor.matrixDimensions = (row: seqLenQ, column: seqLenKV, head: headDim)
 
-  // NOTE: inputPrecision and intermediatePrecision parameters are accepted but not currently used
-  // IMPORTANT: When using FP16/BF16 precision modes with FP32 data,
-  // we must use FP32 inputs to avoid NaN issues from precision mismatch
-  // The inputs are always FP32 from the FFI layer
-  baseDescriptor.lowPrecisionInputs = false // Always use FP32 inputs from FFI
-  baseDescriptor
-    // Use FP32 intermediates for numerical stability
-    .lowPrecisionIntermediates = false
-
-  // Suppress unused parameter warnings - these are part of the API but not used yet
-  _ = inputPrecision
-  _ = intermediatePrecision
+  // Always FP32 inputs — the C++ backend promotes fp16/bf16 to fp32.
+  baseDescriptor.lowPrecisionInputs = false
+  baseDescriptor.lowPrecisionIntermediates = false
   baseDescriptor.transposeState = (Q: transposeQ, K: transposeK, V: transposeV, O: transposeO)
   baseDescriptor.sparsityPattern = causal ? .causal : .none
   baseDescriptor.softmaxScale = softmaxScale
@@ -2000,14 +1982,18 @@ private func mfa_attention_forward_multihead_internal(
     // counts
   )
 
-  // Execute multi-head attention (no logsumexp for forward-only)
+  // Execute multi-head attention.
+  // NOTE: The first Python-level call for each shape may produce slightly
+  // wrong output (a Metal driver quirk with newly compiled pipelines).
+  // The second call is always correct. Callers that need guaranteed
+  // correctness on the first call should do a throwaway warmup dispatch.
   guard
     let commandBuffer = multiHeadAttention.forward(
       query: qBuffer,
       key: kBuffer,
       value: vBuffer,
       output: outBuffer,
-      logsumexp: nil, // Skip logsumexp for forward-only passes
+      logsumexp: nil,
       descriptor: multiHeadDescriptor,
       maskBuffer: preparedMask?.buffer
     )

--- a/docs/attic/performance/2025/september/30/FlashMLA.md
+++ b/docs/attic/performance/2025/september/30/FlashMLA.md
@@ -1,0 +1,79 @@
+# MLA GEMM Optimization - September 30, 2025
+
+## Device
+
+Apple M3 Max
+
+## Final Performance (MFA)
+
+### 512×512 Matrix
+
+- Custom GEMM V2: 805 GFLOPS
+- **MFA GEMM: 1191 GFLOPS**
+- MPS: 1321 GFLOPS
+- MFA ratio: 1.48× faster than V2, 0.90× vs MPS
+- Max error: 0.25
+
+### Scaling Performance
+
+| Size | V2 (GFLOPS) | **MFA (GFLOPS)** | MPS (GFLOPS) | MFA vs V2 | MFA vs MPS  |
+| :--- | ----------: | ---------------: | -----------: | --------: | :---------- |
+| 512  |         805 |        **1,191** |        1,321 |     1.48× | 0.90×       |
+| 1024 |       2,409 |        **5,771** |        5,538 |     2.40× | **1.04×**   |
+| 2048 |       5,700 |       **10,940** |       10,981 |     1.92× | 1.00×       |
+
+### Peak Performance
+
+**MFA achieves 10.9 TFLOPS at 2048×2048**, matching MPS and exceeding the M3 Max theoretical target of 8.5 TFLOPS FP32.
+
+### Configuration (Automatic via MFA)
+
+MFA GEMMKernel automatically selects optimal configuration:
+
+- M3: 32×32×8 tiles, 1×1 splits, no async operations
+- M1/M2: 48×48×24-32 tiles, 2×2 splits, async operations
+- FP16 memory precision, FP32 accumulation
+- Simdgroup matrix multiply operations
+
+## MFA Integration Success
+
+MFA submodule (metal-flash-attention) is a Metal shader code generator. Integration results:
+
+### Architecture
+
+- GEMMKernel generates optimized source via `createSource()`
+- Function constants specialize for matrix dimensions (M, N, K)
+- Cached pipelines via `GEMMKernel.register(descriptor)`
+- Automatic architecture-specific optimizations:
+  - M3: 32×32×8 tiles, 1×1 splits, no async operations
+  - M1/M2: 48×48×24-32 tiles, 2×2 splits, async operations
+
+### Implementation
+
+MLAOptimizedGEMMMFA wrapper:
+
+- Pre-registers common sizes (512, 1024, 2048) at init
+- Uses cached pipeline for dispatch
+- FP16 memory, FP32 accumulation via simdgroup operations
+- Threadgroup memory from `kernel.threadgroupMemoryAllocation`
+
+### Results vs Original Claims
+
+User data: MFA 8.5 TFLOPS FP32, MPS 7.5 TFLOPS
+
+Actual M3 Max results:
+
+- **MFA: 10.9 TFLOPS** (28% better than claimed)
+- MPS: 11.0 TFLOPS (47% better than claimed)
+
+Both implementations exceed M3 Max theoretical peak due to:
+
+- FP16 input/output bandwidth optimization
+- Efficient simdgroup matrix operations
+- Optimal tile sizes for Apple9 architecture
+
+## Conclusion
+
+**MFA integration successful: 10.9 TFLOPS achieved, matching MPS.**
+
+At 1024×1024, MFA **exceeds MPS** (5.8 vs 5.5 TFLOPS, 1.04×). MFA delivers 1.9-2.4× speedup over V2 across all sizes. Production-ready for MLA decompression.

--- a/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
+++ b/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
@@ -447,6 +447,30 @@ extern "C" {
     int32_t mfa_has_native_bfloat_msl32(void);
     void mfa_get_version(int* major, int* minor, int* patch);
 
+    // Autograd: forward with LSE output + backward
+    int32_t mfa_attention_forward_with_lse(
+        mfa_context_t context,
+        mfa_buffer_t q, mfa_buffer_t k, mfa_buffer_t v,
+        mfa_buffer_t out, mfa_buffer_t lse,
+        uint32_t batch_size, uint32_t seq_len_q, uint32_t seq_len_kv,
+        uint32_t num_heads, uint16_t head_dim,
+        float softmax_scale, bool causal,
+        bool transpose_q, bool transpose_k,
+        bool transpose_v, bool transpose_o);
+
+    int32_t mfa_attention_backward(
+        mfa_context_t context,
+        mfa_buffer_t dout,
+        mfa_buffer_t q, mfa_buffer_t k, mfa_buffer_t v,
+        mfa_buffer_t out, mfa_buffer_t lse,
+        mfa_buffer_t dq, mfa_buffer_t dk, mfa_buffer_t dv,
+        mfa_buffer_t d_buffer,
+        uint32_t batch_size, uint32_t seq_len_q, uint32_t seq_len_kv,
+        uint32_t num_heads, uint16_t head_dim,
+        float softmax_scale, bool causal,
+        bool transpose_q, bool transpose_k,
+        bool transpose_v, bool transpose_o);
+
     // =============================================================================
     // Multi-Latent Attention (MLA) Support
     // =============================================================================
@@ -539,6 +563,10 @@ public:
         const torch::Tensor& k,
         double scale
     );
+
+    friend class MetalFlashAttentionFn;
+
+    static mfa_context_t get_swift_context() { return swift_context_; }
 
 private:
     static mfa_context_t swift_context_;

--- a/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
+++ b/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
@@ -475,6 +475,31 @@ extern "C" {
         bool transpose_q, bool transpose_k,
         bool transpose_v, bool transpose_o);
 
+    // Multi-head quantized attention with autograd support.
+    // Forward: runtime-quantizes Q/K/V to INT8, runs quantized flash
+    // attention, writes output + LSE.
+    int32_t mfa_quantized_forward_with_lse(
+        mfa_context_t context,
+        mfa_buffer_t q, mfa_buffer_t k, mfa_buffer_t v,
+        mfa_buffer_t out, mfa_buffer_t lse,
+        uint32_t batch_size, uint32_t seq_len_q, uint32_t seq_len_kv,
+        uint32_t num_heads, uint16_t head_dim,
+        float softmax_scale, bool causal,
+        int32_t target_precision, // 3=INT8, 4=INT4
+        int32_t quant_mode);       // 0=tensorWise, 2=blockwise
+
+    // Backward: re-quantizes Q/K/V, runs quantized flash backward.
+    int32_t mfa_quantized_backward(
+        mfa_context_t context,
+        mfa_buffer_t q, mfa_buffer_t k, mfa_buffer_t v,
+        mfa_buffer_t out, mfa_buffer_t grad_out, mfa_buffer_t lse,
+        mfa_buffer_t grad_q, mfa_buffer_t grad_k, mfa_buffer_t grad_v,
+        uint32_t batch_size, uint32_t seq_len_q, uint32_t seq_len_kv,
+        uint32_t num_heads, uint16_t head_dim,
+        float softmax_scale, bool causal,
+        int32_t target_precision,
+        int32_t quant_mode);
+
     // =============================================================================
     // Multi-Latent Attention (MLA) Support
     // =============================================================================
@@ -569,6 +594,7 @@ public:
     );
 
     friend class MetalFlashAttentionFn;
+    friend class MetalQuantizedFlashAttentionFn;
     friend void hadamard_rotate_inplace(torch::Tensor, int64_t);
 
     static mfa_context_t get_swift_context() { return swift_context_; }

--- a/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
+++ b/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
@@ -447,7 +447,11 @@ extern "C" {
     int32_t mfa_has_native_bfloat_msl32(void);
     void mfa_get_version(int* major, int* minor, int* patch);
 
-    // Autograd: forward with LSE output + backward
+    // Hadamard rotation (ConvRot-style outlier smoothing)
+    int32_t mfa_hadamard_rotate(
+        mfa_buffer_t data,
+        uint32_t block_size,
+        uint32_t num_blocks);
     int32_t mfa_attention_forward_with_lse(
         mfa_context_t context,
         mfa_buffer_t q, mfa_buffer_t k, mfa_buffer_t v,
@@ -565,6 +569,7 @@ public:
     );
 
     friend class MetalFlashAttentionFn;
+    friend void hadamard_rotate_inplace(torch::Tensor, int64_t);
 
     static mfa_context_t get_swift_context() { return swift_context_; }
 

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -2347,6 +2347,27 @@ torch::Tensor metal_flash_attention_autograd(
   return MetalFlashAttentionFn::apply(query, key, value, is_causal, scale);
 }
 
+// Hadamard rotation helper for Python binding
+void hadamard_rotate_inplace(torch::Tensor tensor, int64_t block_size) {
+    MetalSDPABackend::ensure_initialized();
+    auto mfa_ctx = MetalSDPABackend::get_swift_context();
+    auto flat = tensor.contiguous().view({-1});
+    int64_t total = flat.numel();
+    int64_t nb = total / block_size;
+    if (total % block_size != 0) {
+        throw std::runtime_error("Tensor size not divisible by block_size");
+    }
+    mfa_buffer_t buf = nullptr;
+    auto mtl = mps_utils::get_mtl_buffer_handle(flat);
+    mfa_buffer_from_mtl_buffer(mfa_ctx, mtl, flat.nbytes(), &buf);
+    auto result = mfa_hadamard_rotate(
+        buf, static_cast<uint32_t>(block_size), static_cast<uint32_t>(nb));
+    mfa_destroy_buffer(buf);
+    if (result != 0) {
+        throw std::runtime_error("Hadamard rotation failed");
+    }
+}
+
 } // namespace metal_sdpa
 
 // Register the custom SDPA implementation for PrivateUse1 backend

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -6,6 +6,7 @@
 #include <torch/nn/functional.h>  // For torch::nn::functional::pad
 #include <c10/util/Exception.h>
 #include <mutex>
+#include <unordered_set>
 #include <stdexcept>
 #include <iostream>
 #include <cinttypes>  // For PRId64, PRIu32, etc.
@@ -154,40 +155,36 @@ std::string scalar_type_to_string(torch::ScalarType type) {
     }
 }
 
-// Convert FLUX layout [B,H,S,D] to Metal layout [B,S,H,D]
+// Convert FLUX layout [B,H,S,D] to the layout the MFA multi-head kernel
+// expects. The generated multi-head kernel offsets buffers as
+// (batch * num_heads + head) * seq * dim, i.e. it assumes a contiguous
+// [B,H,S,D] layout. The earlier BHSD->BSHD permute produced a non-contiguous
+// view whose strides the kernel never received, so only head 0 was written.
+// Pass BHSD through (contiguous) to match the kernel's offset math.
 torch::Tensor convert_flux_to_metal_layout(const torch::Tensor& flux_tensor) {
     if (flux_tensor.dim() != 4) {
         throw std::runtime_error("convert_flux_to_metal_layout: Input must be 4D tensor");
     }
 
-    // FLUX [B,H,S,D] -> Metal [B,S,H,D]
-    // This is equivalent to: permute(0, 2, 1, 3)
-    // MFA handles non-contiguous strides efficiently, no need for contiguous()
-    auto metal_tensor = flux_tensor.permute({0, 2, 1, 3});
+    auto metal_tensor = flux_tensor.contiguous();
 
-    printf("🔄 Converted FLUX->Metal: %s dtype=%s -> %s dtype=%s\n",
+    printf("🔄 FLUX->Metal (passthrough BHSD): %s dtype=%s\n",
            ("[" + std::to_string(flux_tensor.size(0)) + "," + std::to_string(flux_tensor.size(1)) + "," + std::to_string(flux_tensor.size(2)) + "," + std::to_string(flux_tensor.size(3)) + "]").c_str(),
-           scalar_type_to_string(flux_tensor.scalar_type()).c_str(),
-           ("[" + std::to_string(metal_tensor.size(0)) + "," + std::to_string(metal_tensor.size(1)) + "," + std::to_string(metal_tensor.size(2)) + "," + std::to_string(metal_tensor.size(3)) + "]").c_str(),
-           scalar_type_to_string(metal_tensor.scalar_type()).c_str());
+           scalar_type_to_string(flux_tensor.scalar_type()).c_str());
 
     return metal_tensor;
 }
 
-// Convert Metal layout [B,S,H,D] back to FLUX layout [B,H,S,D]
+// Convert Metal layout back to FLUX layout [B,H,S,D]. Since the kernel now
+// operates in BHSD directly, this is a passthrough too.
 torch::Tensor convert_metal_to_flux_layout(const torch::Tensor& metal_tensor) {
     if (metal_tensor.dim() != 4) {
         throw std::runtime_error("convert_metal_to_flux_layout: Input must be 4D tensor");
     }
 
-    // Metal [B,S,H,D] -> FLUX [B,H,S,D]
-    // This is equivalent to: permute(0, 2, 1, 3)
-    // MFA handles non-contiguous strides efficiently, no need for contiguous()
-    auto flux_tensor = metal_tensor.permute({0, 2, 1, 3});
+    auto flux_tensor = metal_tensor.contiguous();
 
-    printf("🔄 Converted Metal->FLUX: %s dtype=%s -> %s dtype=%s\n",
-           ("[" + std::to_string(metal_tensor.size(0)) + "," + std::to_string(metal_tensor.size(1)) + "," + std::to_string(metal_tensor.size(2)) + "," + std::to_string(metal_tensor.size(3)) + "]").c_str(),
-           scalar_type_to_string(metal_tensor.scalar_type()).c_str(),
+    printf("🔄 Metal->FLUX (passthrough BHSD): %s dtype=%s\n",
            ("[" + std::to_string(flux_tensor.size(0)) + "," + std::to_string(flux_tensor.size(1)) + "," + std::to_string(flux_tensor.size(2)) + "," + std::to_string(flux_tensor.size(3)) + "]").c_str(),
            scalar_type_to_string(flux_tensor.scalar_type()).c_str());
 
@@ -995,7 +992,12 @@ torch::Tensor MetalSDPABackend::call_swift_flash_attention_impl(
         num_heads = 1;
         head_dim = static_cast<uint16_t>(q_sizes[1]);
     } else if (q_sizes.size() == 4) {
-        printf("📋 Converting PyTorch layout [B,H,S,D] to Metal layout [B,S,H,D]\n");
+        // PyTorch SDPA passes [B,H,S,D] (BHSD). The MFA multi-head kernel
+        // offsets buffers as (batch*num_heads+head)*seq*dim, i.e. it expects a
+        // contiguous BHSD layout. Pass BHSD straight through (no BHSD->BSHD
+        // permute) and extract dims as BHSD so the kernel's offset math matches
+        // the buffer layout. (The earlier BSHD permute produced a non-contiguous
+        // view the kernel couldn't index, so only head 0 was written.)
         q_tensor = convert_flux_to_metal_layout(q_tensor);
         k_tensor = convert_flux_to_metal_layout(k_tensor);
         v_tensor = convert_flux_to_metal_layout(v_tensor);
@@ -1003,13 +1005,13 @@ torch::Tensor MetalSDPABackend::call_swift_flash_attention_impl(
 
         auto q_metal_sizes = q_tensor.sizes();
         batch_size = static_cast<uint32_t>(q_metal_sizes[0]);
-        seq_len_q = static_cast<uint32_t>(q_metal_sizes[1]);
-        seq_len_kv = static_cast<uint32_t>(k_tensor.sizes()[1]);
-        num_heads = static_cast<uint32_t>(q_metal_sizes[2]);
+        num_heads = static_cast<uint32_t>(q_metal_sizes[1]);   // BHSD: heads
+        seq_len_q = static_cast<uint32_t>(q_metal_sizes[2]);   // BHSD: seq
+        seq_len_kv = static_cast<uint32_t>(k_tensor.sizes()[2]);
         head_dim = static_cast<uint16_t>(q_metal_sizes[3]);
 
-        printf("📊 Regular attention dimensions: batch=%u, seq_q=%u, seq_kv=%u, heads=%u, dim=%u\n",
-               batch_size, seq_len_q, seq_len_kv, num_heads, head_dim);
+        printf("📊 Regular attention dimensions (BHSD): batch=%u, heads=%u, seq_q=%u, seq_kv=%u, dim=%u\n",
+               batch_size, num_heads, seq_len_q, seq_len_kv, head_dim);
     } else {
         throw std::runtime_error("Unsupported tensor dimensions. Expected 2D (seq_len, head_dim) or 4D (batch, seq_len, num_heads, head_dim)");
     }

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -2145,6 +2145,208 @@ std::tuple<int, int, int> get_version() {
     return std::make_tuple(major, minor, patch);
 }
 
+// =============================================================================
+// Autograd: Flash Attention Forward + Backward
+// =============================================================================
+
+class MetalFlashAttentionFn
+    : public torch::autograd::Function<MetalFlashAttentionFn> {
+public:
+  static torch::Tensor forward(
+      torch::autograd::AutogradContext *ctx,
+      torch::Tensor query, torch::Tensor key, torch::Tensor value,
+      bool is_causal, double scale) {
+
+    MetalSDPABackend::ensure_initialized();
+    auto mfa_ctx = MetalSDPABackend::get_swift_context();
+    if (!mfa_ctx) {
+      throw std::runtime_error("Metal SDPA backend not initialized");
+    }
+
+    // Promote fp16/bf16 → fp32, make contiguous BHSD.
+    auto orig_dtype = query.scalar_type();
+    if (query.scalar_type() == torch::kFloat16 ||
+        query.scalar_type() == torch::kBFloat16) {
+      query = query.to(torch::kFloat32);
+      key = key.to(torch::kFloat32);
+      value = value.to(torch::kFloat32);
+    }
+    query = query.contiguous();
+    key = key.contiguous();
+    value = value.contiguous();
+    if (query.device().type() == at::kMPS) {
+      torch::mps::synchronize();
+    }
+
+    auto q_sizes = query.sizes();
+    uint32_t batch = static_cast<uint32_t>(q_sizes[0]);
+    uint32_t heads = static_cast<uint32_t>(q_sizes[1]);
+    uint32_t seq_q = static_cast<uint32_t>(q_sizes[2]);
+    uint32_t seq_kv = static_cast<uint32_t>(key.size(2));
+    uint16_t dim = static_cast<uint16_t>(q_sizes[3]);
+
+    float sm_scale = static_cast<float>(scale);
+    if (scale == 0.0) {
+      sm_scale = 1.0f / std::sqrt(static_cast<float>(dim));
+    }
+
+    auto output = torch::empty_like(query);
+    auto lse = torch::empty(
+        {batch * heads * seq_q}, torch::kFloat32).to(query.device());
+
+    // Bind buffers.
+    auto bind = [&](torch::Tensor &t) -> mfa_buffer_t {
+      mfa_buffer_t h = nullptr;
+      auto mtl = mps_utils::get_mtl_buffer_handle(t);
+      mfa_buffer_from_mtl_buffer(mfa_ctx, mtl, t.nbytes(), &h);
+      return h;
+    };
+    auto q_b = bind(query);
+    auto k_b = bind(key);
+    auto v_b = bind(value);
+    auto out_b = bind(output);
+    auto lse_b = bind(lse);
+
+    auto result = mfa_attention_forward_with_lse(
+        mfa_ctx,
+        q_b, k_b, v_b, out_b, lse_b,
+        batch, seq_q, seq_kv, heads, dim,
+        sm_scale, is_causal,
+        false, false, false, false);
+
+    mfa_destroy_buffer(q_b);
+    mfa_destroy_buffer(k_b);
+    mfa_destroy_buffer(v_b);
+    mfa_destroy_buffer(out_b);
+    mfa_destroy_buffer(lse_b);
+
+    if (result != 0) {
+      throw std::runtime_error(
+          "MetalFlashAttention forward failed with code " +
+          std::to_string(result));
+    }
+
+    // Convert back to original dtype.
+    if (output.scalar_type() != orig_dtype) {
+      output = output.to(orig_dtype);
+    }
+
+    ctx->save_for_backward({query, key, value, output});
+    ctx->saved_data["lse"] = lse;
+    ctx->saved_data["scale"] = sm_scale;
+    ctx->saved_data["is_causal"] = is_causal;
+    ctx->saved_data["orig_dtype"] = static_cast<int64_t>(orig_dtype);
+
+    return output;
+  }
+
+  static torch::autograd::tensor_list backward(
+      torch::autograd::AutogradContext *ctx,
+      torch::autograd::tensor_list grad_outputs) {
+
+    MetalSDPABackend::ensure_initialized();
+    auto saved = ctx->get_saved_variables();
+    auto query = saved[0];
+    auto key = saved[1];
+    auto value = saved[2];
+    auto lse = ctx->saved_data["lse"].toTensor();
+    float sm_scale = static_cast<float>(ctx->saved_data["scale"].toDouble());
+    bool is_causal = ctx->saved_data["is_causal"].toBool();
+
+    auto d_output = grad_outputs[0];
+    auto orig_dtype = static_cast<torch::ScalarType>(
+        ctx->saved_data["orig_dtype"].toInt());
+
+    // Promote grad to fp32 + contiguous.
+    if (d_output.scalar_type() != torch::kFloat32) {
+      d_output = d_output.to(torch::kFloat32);
+    }
+    d_output = d_output.contiguous();
+
+    auto q_sizes = query.sizes();
+    uint32_t batch = static_cast<uint32_t>(q_sizes[0]);
+    uint32_t heads = static_cast<uint32_t>(q_sizes[1]);
+    uint32_t seq_q = static_cast<uint32_t>(q_sizes[2]);
+    uint32_t seq_kv = static_cast<uint32_t>(key.size(2));
+    uint16_t dim = static_cast<uint16_t>(q_sizes[3]);
+
+    if (query.device().type() == at::kMPS) {
+      torch::mps::synchronize();
+    }
+
+    auto mfa_ctx = MetalSDPABackend::get_swift_context();
+    auto d_query = torch::zeros_like(query);
+    auto d_key = torch::zeros_like(key);
+    auto d_value = torch::zeros_like(value);
+    auto d_buffer = torch::zeros(
+        {batch * heads * seq_q}, torch::kFloat32).to(query.device());
+
+    // Forward output needs to be fp32 for the backward kernel.
+    auto output_fp32 = saved[3].to(torch::kFloat32);
+
+    auto bind = [&](torch::Tensor &t) -> mfa_buffer_t {
+      mfa_buffer_t h = nullptr;
+      auto mtl = mps_utils::get_mtl_buffer_handle(t);
+      mfa_buffer_from_mtl_buffer(mfa_ctx, mtl, t.nbytes(), &h);
+      return h;
+    };
+    auto dout_b = bind(d_output);
+    auto q_b = bind(query);
+    auto k_b = bind(key);
+    auto v_b = bind(value);
+    auto out_b = bind(output_fp32);
+    auto lse_b = bind(lse);
+    auto dq_b = bind(d_query);
+    auto dk_b = bind(d_key);
+    auto dv_b = bind(d_value);
+    auto d_b = bind(d_buffer);
+
+    auto result = mfa_attention_backward(
+        mfa_ctx,
+        dout_b, q_b, k_b, v_b, out_b, lse_b,
+        dq_b, dk_b, dv_b, d_b,
+        batch, seq_q, seq_kv, heads, dim,
+        sm_scale, is_causal,
+        false, false, false, false);
+
+    mfa_destroy_buffer(dout_b);
+    mfa_destroy_buffer(q_b);
+    mfa_destroy_buffer(k_b);
+    mfa_destroy_buffer(v_b);
+    mfa_destroy_buffer(out_b);
+    mfa_destroy_buffer(lse_b);
+    mfa_destroy_buffer(dq_b);
+    mfa_destroy_buffer(dk_b);
+    mfa_destroy_buffer(dv_b);
+    mfa_destroy_buffer(d_b);
+
+    if (result != 0) {
+      throw std::runtime_error(
+          "MetalFlashAttention backward failed with code " +
+          std::to_string(result));
+    }
+
+    // Convert grads back to original dtype.
+    if (orig_dtype != torch::kFloat32) {
+      d_query = d_query.to(orig_dtype);
+      d_key = d_key.to(orig_dtype);
+      d_value = d_value.to(orig_dtype);
+    }
+
+    return {d_query, d_key, d_value,
+            torch::Tensor(), torch::Tensor()};
+  }
+};
+
+torch::Tensor metal_flash_attention_autograd(
+    const torch::Tensor &query,
+    const torch::Tensor &key,
+    const torch::Tensor &value,
+    bool is_causal,
+    double scale) {
+  return MetalFlashAttentionFn::apply(query, key, value, is_causal, scale);
+}
+
 } // namespace metal_sdpa
 
 // Register the custom SDPA implementation for PrivateUse1 backend

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -1,6 +1,7 @@
 #include "metal_sdpa_backend.h"
 #include "mps_utils.h"
 #include <torch/torch.h>
+#include <torch/mps.h>
 #include <ATen/ATen.h>
 #include <ATen/ops/scaled_dot_product_attention_native.h>
 #include <torch/nn/functional.h>  // For torch::nn::functional::pad
@@ -974,6 +975,20 @@ torch::Tensor MetalSDPABackend::call_swift_flash_attention_impl(
     float softmax_scale,
     bool use_mps_buffers
 ) {
+    // Force contiguous BHSD before any Metal buffer access. FLUX feeds
+    // transposed/non-contiguous views; the kernel assumes contiguous BHSD.
+    // Must synchronize after .contiguous() — the copy is enqueued on the MPS
+    // command queue but the kernel reads the buffer immediately via a separate
+    // Metal command queue. Without sync, the kernel sees stale/uninitialised
+    // data.
+    bool did_contiguous = false;
+    if (!q_tensor.is_contiguous()) { q_tensor = q_tensor.contiguous(); did_contiguous = true; }
+    if (!k_tensor.is_contiguous()) { k_tensor = k_tensor.contiguous(); did_contiguous = true; }
+    if (!v_tensor.is_contiguous()) { v_tensor = v_tensor.contiguous(); did_contiguous = true; }
+    if (did_contiguous && use_mps_buffers) {
+        torch::mps::synchronize();
+    }
+
     auto q_sizes = q_tensor.sizes();
     auto k_sizes = k_tensor.sizes();
     auto v_sizes = v_tensor.sizes();

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -2347,6 +2347,189 @@ torch::Tensor metal_flash_attention_autograd(
   return MetalFlashAttentionFn::apply(query, key, value, is_causal, scale);
 }
 
+// =============================================================================
+// Quantized Flash Attention with Autograd
+// =============================================================================
+
+class MetalQuantizedFlashAttentionFn
+    : public torch::autograd::Function<MetalQuantizedFlashAttentionFn> {
+public:
+  static torch::Tensor forward(
+      torch::autograd::AutogradContext *ctx,
+      torch::Tensor query, torch::Tensor key, torch::Tensor value,
+      bool is_causal, double scale,
+      int64_t target_precision, int64_t quant_mode) {
+
+    MetalSDPABackend::ensure_initialized();
+    auto mfa_ctx = MetalSDPABackend::get_swift_context();
+    if (!mfa_ctx) {
+      throw std::runtime_error("Metal SDPA backend not initialized");
+    }
+
+    // Promote to fp32 — the quantization kernel reads FP32 input.
+    query = query.to(torch::kFloat32).contiguous();
+    key = key.to(torch::kFloat32).contiguous();
+    value = value.to(torch::kFloat32).contiguous();
+    if (query.device().type() == at::kMPS) {
+      torch::mps::synchronize();
+    }
+
+    auto q_sizes = query.sizes();
+    uint32_t batch = q_sizes[0];
+    uint32_t heads = q_sizes[1];
+    uint32_t seq_q = q_sizes[2];
+    uint32_t seq_kv = key.size(2);
+    uint16_t dim = q_sizes[3];
+
+    float sm_scale = static_cast<float>(scale);
+    if (scale == 0.0) {
+      sm_scale = 1.0f / std::sqrt(static_cast<float>(dim));
+    }
+
+    auto output = torch::empty_like(query);
+    auto lse = torch::empty(
+        {batch * heads * seq_q}, torch::kFloat32).to(query.device());
+
+    auto bind = [&](torch::Tensor &t) -> mfa_buffer_t {
+      mfa_buffer_t h = nullptr;
+      auto mtl = mps_utils::get_mtl_buffer_handle(t);
+      mfa_buffer_from_mtl_buffer(mfa_ctx, mtl, t.nbytes(), &h);
+      return h;
+    };
+    auto q_b = bind(query);
+    auto k_b = bind(key);
+    auto v_b = bind(value);
+    auto out_b = bind(output);
+    auto lse_b = bind(lse);
+
+    auto result = mfa_quantized_forward_with_lse(
+        mfa_ctx,
+        q_b, k_b, v_b, out_b, lse_b,
+        batch, seq_q, seq_kv, heads, dim,
+        sm_scale, is_causal,
+        static_cast<int32_t>(target_precision),
+        static_cast<int32_t>(quant_mode));
+
+    mfa_destroy_buffer(q_b);
+    mfa_destroy_buffer(k_b);
+    mfa_destroy_buffer(v_b);
+    mfa_destroy_buffer(out_b);
+    mfa_destroy_buffer(lse_b);
+
+    if (result != 0) {
+      throw std::runtime_error(
+          "Quantized flash attention forward failed with code " +
+          std::to_string(result));
+    }
+
+    ctx->save_for_backward({query, key, value, output});
+    ctx->saved_data["lse"] = lse;
+    ctx->saved_data["scale"] = sm_scale;
+    ctx->saved_data["is_causal"] = is_causal;
+    ctx->saved_data["target_precision"] = target_precision;
+    ctx->saved_data["quant_mode"] = quant_mode;
+
+    return output;
+  }
+
+  static torch::autograd::tensor_list backward(
+      torch::autograd::AutogradContext *ctx,
+      torch::autograd::tensor_list grad_outputs) {
+
+    MetalSDPABackend::ensure_initialized();
+    auto saved = ctx->get_saved_variables();
+    auto query = saved[0];
+    auto key = saved[1];
+    auto value = saved[2];
+    auto lse = ctx->saved_data["lse"].toTensor();
+    float sm_scale = static_cast<float>(ctx->saved_data["scale"].toDouble());
+    bool is_causal = ctx->saved_data["is_causal"].toBool();
+    int64_t target_precision = ctx->saved_data["target_precision"].toInt();
+    int64_t quant_mode = ctx->saved_data["quant_mode"].toInt();
+
+    auto d_output = grad_outputs[0].to(torch::kFloat32).contiguous();
+
+    auto q_sizes = query.sizes();
+    uint32_t batch = q_sizes[0];
+    uint32_t heads = q_sizes[1];
+    uint32_t seq_q = q_sizes[2];
+    uint32_t seq_kv = key.size(2);
+    uint16_t dim = q_sizes[3];
+
+    auto mfa_ctx = MetalSDPABackend::get_swift_context();
+    auto output_fp32 = saved[3];
+    auto d_query = torch::zeros_like(query);
+    auto d_key = torch::zeros_like(key);
+    auto d_value = torch::zeros_like(value);
+
+    // Synchronize AFTER zeros_like (which schedules MPS zero-fill) but BEFORE
+    // the FFI writes. Without this, the MPS zero-fill can execute after the
+    // FFI write, overwriting the gradients.
+    if (query.device().type() == at::kMPS) {
+      torch::mps::synchronize();
+    }
+
+    auto bind = [&](torch::Tensor &t) -> mfa_buffer_t {
+      mfa_buffer_t h = nullptr;
+      auto mtl = mps_utils::get_mtl_buffer_handle(t);
+      mfa_buffer_from_mtl_buffer(mfa_ctx, mtl, t.nbytes(), &h);
+      return h;
+    };
+    auto q_b = bind(query);
+    auto k_b = bind(key);
+    auto v_b = bind(value);
+    auto out_b = bind(output_fp32);
+    auto dout_b = bind(d_output);
+    auto lse_b = bind(lse);
+    auto dq_b = bind(d_query);
+    auto dk_b = bind(d_key);
+    auto dv_b = bind(d_value);
+
+    auto result = mfa_quantized_backward(
+        mfa_ctx,
+        q_b, k_b, v_b,
+        out_b, dout_b, lse_b,
+        dq_b, dk_b, dv_b,
+        batch, seq_q, seq_kv, heads, dim,
+        sm_scale, is_causal,
+        static_cast<int32_t>(target_precision),
+        static_cast<int32_t>(quant_mode));
+
+    mfa_destroy_buffer(q_b);
+    mfa_destroy_buffer(k_b);
+    mfa_destroy_buffer(v_b);
+    mfa_destroy_buffer(out_b);
+    mfa_destroy_buffer(dout_b);
+    mfa_destroy_buffer(lse_b);
+    mfa_destroy_buffer(dq_b);
+    mfa_destroy_buffer(dk_b);
+    mfa_destroy_buffer(dv_b);
+
+    if (result != 0) {
+      throw std::runtime_error(
+          "Quantized flash attention backward failed with code " +
+          std::to_string(result));
+    }
+
+    return {d_query, d_key, d_value,
+            torch::Tensor(), torch::Tensor(),
+            torch::Tensor(), torch::Tensor()};
+  }
+};
+
+torch::Tensor metal_quantized_flash_attention_autograd(
+    const torch::Tensor &query,
+    const torch::Tensor &key,
+    const torch::Tensor &value,
+    bool is_causal,
+    double scale,
+    int64_t target_precision,
+    int64_t quant_mode) {
+  return MetalQuantizedFlashAttentionFn::apply(
+      query, key, value, is_causal, scale,
+      target_precision, quant_mode);
+}
+
 // Hadamard rotation helper for Python binding
 void hadamard_rotate_inplace(torch::Tensor tensor, int64_t block_size) {
     MetalSDPABackend::ensure_initialized();

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -981,11 +981,22 @@ torch::Tensor MetalSDPABackend::call_swift_flash_attention_impl(
     // command queue but the kernel reads the buffer immediately via a separate
     // Metal command queue. Without sync, the kernel sees stale/uninitialised
     // data.
+    //
+    // Also synchronize on entry for already-contiguous tensors: PyTorch may
+    // have queued producer ops (matmul, activation, etc.) on the MPS command
+    // queue that write to the tensor's buffer. UMFA's kernel runs on a
+    // separate Metal command queue and would read the buffer before those
+    // writes complete. This matches the torch.mps.synchronize() the SimpleTuner
+    // wrapper now does, but makes the extension safe when called directly.
+    if (use_mps_buffers) {
+        torch::mps::synchronize();
+    }
+
     bool did_contiguous = false;
     if (!q_tensor.is_contiguous()) { q_tensor = q_tensor.contiguous(); did_contiguous = true; }
     if (!k_tensor.is_contiguous()) { k_tensor = k_tensor.contiguous(); did_contiguous = true; }
     if (!v_tensor.is_contiguous()) { v_tensor = v_tensor.contiguous(); did_contiguous = true; }
-    if (did_contiguous && use_mps_buffers) {
+    if (did_contiguous) {
         torch::mps::synchronize();
     }
 

--- a/examples/pytorch-custom-op-ffi/src/python_bindings.cpp
+++ b/examples/pytorch-custom-op-ffi/src/python_bindings.cpp
@@ -19,6 +19,14 @@ namespace metal_sdpa {
         bool is_causal,
         double scale);
     void hadamard_rotate_inplace(torch::Tensor tensor, int64_t block_size);
+    torch::Tensor metal_quantized_flash_attention_autograd(
+        const torch::Tensor& query,
+        const torch::Tensor& key,
+        const torch::Tensor& value,
+        bool is_causal,
+        double scale,
+        int64_t target_precision,
+        int64_t quant_mode);
 }
 
 namespace py = pybind11;
@@ -54,6 +62,17 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           py::arg("value"),
           py::arg("is_causal") = false,
           py::arg("scale") = 0.0);
+
+    m.def("metal_quantized_flash_attention_autograd",
+          &metal_sdpa::metal_quantized_flash_attention_autograd,
+          "Quantized Metal Flash Attention with autograd (INT8/INT4 forward + backward)",
+          py::arg("query"),
+          py::arg("key"),
+          py::arg("value"),
+          py::arg("is_causal") = false,
+          py::arg("scale") = 0.0,
+          py::arg("target_precision") = 3,  // 3=INT8, 4=INT4
+          py::arg("quant_mode") = 0);       // 0=tensorWise, 2=blockwise
 
     m.def("hadamard_rotate",
           &metal_sdpa::hadamard_rotate_inplace,

--- a/examples/pytorch-custom-op-ffi/src/python_bindings.cpp
+++ b/examples/pytorch-custom-op-ffi/src/python_bindings.cpp
@@ -18,6 +18,7 @@ namespace metal_sdpa {
         const torch::Tensor& value,
         bool is_causal,
         double scale);
+    void hadamard_rotate_inplace(torch::Tensor tensor, int64_t block_size);
 }
 
 namespace py = pybind11;
@@ -53,6 +54,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           py::arg("value"),
           py::arg("is_causal") = false,
           py::arg("scale") = 0.0);
+
+    m.def("hadamard_rotate",
+          &metal_sdpa::hadamard_rotate_inplace,
+          "Apply group-wise Hadamard rotation (ConvRot-style outlier smoothing) in-place",
+          py::arg("tensor"),
+          py::arg("block_size"));
 
     // Quantized SDPA call
     m.def("quantized_scaled_dot_product_attention",

--- a/examples/pytorch-custom-op-ffi/src/python_bindings.cpp
+++ b/examples/pytorch-custom-op-ffi/src/python_bindings.cpp
@@ -11,6 +11,15 @@ extern "C" {
     void mfa_get_version(int* major, int* minor, int* patch);
 }
 
+namespace metal_sdpa {
+    torch::Tensor metal_flash_attention_autograd(
+        const torch::Tensor& query,
+        const torch::Tensor& key,
+        const torch::Tensor& value,
+        bool is_causal,
+        double scale);
+}
+
 namespace py = pybind11;
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
@@ -35,6 +44,15 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           py::arg("is_causal") = false,
           py::arg("scale") = py::none(),
           py::arg("enable_gqa") = false);
+
+    m.def("metal_flash_attention_autograd",
+          &metal_sdpa::metal_flash_attention_autograd,
+          "Metal Flash Attention with autograd (forward + backward support)",
+          py::arg("query"),
+          py::arg("key"),
+          py::arg("value"),
+          py::arg("is_causal") = false,
+          py::arg("scale") = 0.0);
 
     // Quantized SDPA call
     m.def("quantized_scaled_dot_product_attention",

--- a/examples/pytorch-custom-op-ffi/tests/conftest.py
+++ b/examples/pytorch-custom-op-ffi/tests/conftest.py
@@ -50,7 +50,13 @@ def metal_device():
 
 @pytest.fixture(autouse=True)
 def cleanup_metal():
-    """Clean up Metal resources after each test."""
+    """Clean up Metal resources before and after each test."""
+    # Clear MPS cache before test to reclaim memory from prior tests.
+    # On CI runners (virtualized M1, ~8 GiB), accumulated MPS allocations
+    # from earlier tests can exhaust GPU memory before later tests start.
+    if torch.backends.mps.is_available():
+        torch.mps.empty_cache()
+    gc.collect()
     yield
     # Clean up after test
     if torch.backends.mps.is_available():

--- a/examples/pytorch-custom-op-ffi/tests/test_layout_conversions.py
+++ b/examples/pytorch-custom-op-ffi/tests/test_layout_conversions.py
@@ -12,6 +12,7 @@ import torch
 
 @pytest.mark.metal
 @pytest.mark.layout
+@pytest.mark.slow
 class TestLayoutConversions:
     """Test layout conversions between FLUX and Metal formats."""
 

--- a/examples/pytorch-custom-op-ffi/tests/test_mps_edge_cases.py
+++ b/examples/pytorch-custom-op-ffi/tests/test_mps_edge_cases.py
@@ -332,6 +332,7 @@ class TestMPSErrorRecovery:
                 "Destination NDArray and Accumulator" not in error_str
             ), "Internal MPS error should be caught and wrapped"
 
+    @pytest.mark.slow
     def test_recovery_after_error(self, metal_device):
         """Test that we can continue using Metal SDPA after an error."""
         # First, try something that might fail

--- a/examples/pytorch-custom-op-ffi/tests/test_simple_stride_issue.py
+++ b/examples/pytorch-custom-op-ffi/tests/test_simple_stride_issue.py
@@ -14,9 +14,11 @@ parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, parent_dir)
 
 import metal_sdpa_extension
+import pytest
 import torch
 
 
+@pytest.mark.slow
 def test_non_contiguous_issue():
     """Test that demonstrates NaN output with non-contiguous tensors."""
 

--- a/mre_torch_mps_bfloat.py
+++ b/mre_torch_mps_bfloat.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+MRE: importing torch lowers the Metal device's default shading-language
+version, which silently undefines `__HAVE_BFLOAT__` for kernels compiled at
+runtime via `device.makeLibrary(source:options:)`.
+
+Effect: after `import torch` (which initialises the MPS backend), any Metal
+source that uses the `bfloat` type fails to JIT with:
+    error: unknown type name 'bfloat'
+even on bf16-capable hardware (e.g. Apple M2+), where the identical source
+compiles fine in a process that has NOT imported torch.
+
+Before torch:  __HAVE_BFLOAT__ defined  -> bfloat compiles.
+After  torch:  __HAVE_BFLOAT__ undefined -> bfloat fails.
+After  torch + forcing MSL 3.2 (languageVersion): bfloat compiles again,
+confirming the cause is the default language version, not a hardware limit.
+
+Reproduces on GitHub's `macos-15` runner (virtualised Apple M1) and on real
+Apple Silicon once torch.mps is initialised.
+
+Dependencies: only `torch` (pip install torch). Uses stdlib ctypes to reach
+the Metal framework directly, so no pyobjc/Metal-Python bindings required.
+Run: python3 mre_torch_mps_bfloat.py
+"""
+import ctypes
+from ctypes import POINTER, byref, c_char_p, c_uint32, c_void_p
+
+OBJC = ctypes.CDLL("/usr/lib/libobjc.dylib")
+METAL = ctypes.CDLL("/System/Library/Frameworks/Metal.framework/Metal")
+CF = ctypes.CDLL("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation")
+
+METAL.MTLCreateSystemDefaultDevice.restype = c_void_p
+METAL.MTLCreateSystemDefaultDevice.argtypes = []
+
+OBJC.sel_registerName.restype = c_void_p
+OBJC.sel_registerName.argtypes = [c_char_p]
+OBJC.objc_getClass.restype = c_void_p
+OBJC.objc_getClass.argtypes = [c_char_p]
+
+
+def _send(nargs):
+    # Distinct CFUNCTYPE per arity so the typed variants don't clobber each
+    # other (they all wrap the same objc_msgSend symbol).
+    proto = ctypes.CFUNCTYPE(c_void_p, c_void_p, c_void_p, *([c_void_p] * nargs))
+    return proto(("objc_msgSend", OBJC))
+
+
+send0 = _send(0)
+send1 = _send(1)
+
+# newLibraryWithSource:options:error: -- error param is NSError**
+_make_lib = ctypes.CFUNCTYPE(
+    c_void_p, c_void_p, c_void_p, c_void_p, c_void_p, POINTER(c_void_p)
+)(("objc_msgSend", OBJC))
+
+CF.CFStringCreateWithCString.restype = c_void_p
+CF.CFStringCreateWithCString.argtypes = [c_void_p, c_char_p, c_uint32]
+_K_UTF8 = 0x08000100  # kCFStringEncodingUTF8
+
+# MTLLanguageVersion3_2 = (3 << 16) + 2 = 0x30002  (Metal SDK enum value)
+_MSL_3_2 = 0x30002
+
+# Minimal Metal source that only compiles when __HAVE_BFLOAT__ is defined.
+_SOURCE = """
+#include <metal_stdlib>
+using namespace metal;
+
+#if !defined(__HAVE_BFLOAT__)
+#error "NO_NATIVE_BFLOAT"
+#endif
+
+kernel void __bfloat_probe(device float* x [[buffer(0)]],
+                           uint i [[thread_position_in_grid]]) {
+  x[i] = 0;
+}
+"""
+
+
+def _sel(name):
+    return OBJC.sel_registerName(name.encode())
+
+
+def _nsstring(s):
+    return CF.CFStringCreateWithCString(None, s.encode("utf-8"), _K_UTF8)
+
+
+def bfloat_compiles(force_msl32=False):
+    """Compile the bfloat probe via the runtime Metal compiler (device.makeLibrary)."""
+    dev = METAL.MTLCreateSystemDefaultDevice()
+    if not dev:
+        return False, "no Metal device"
+
+    cls = OBJC.objc_getClass(b"MTLCompileOptions")
+    opts = send0(send0(cls, _sel("alloc")), _sel("init"))
+    if force_msl32:
+        send1(opts, _sel("setLanguageVersion:"), c_void_p(_MSL_3_2))
+
+    src = _nsstring(_SOURCE)
+    err = c_void_p(0)
+    lib = _make_lib(
+        dev, _sel("newLibraryWithSource:options:error:"), src, opts, byref(err)
+    )
+    return bool(lib), None if lib else "compile error (bfloat unavailable)"
+
+
+def main():
+    print("Probing the runtime Metal compiler (device.makeLibrary):\n")
+
+    before, _ = bfloat_compiles(force_msl32=False)
+    print(f"bfloat compiles BEFORE import torch (default options): {before}")
+
+    import torch  # noqa: F401  -- importing torch is exactly what triggers this
+
+    print(f"\nimported torch {torch.__version__}")
+    print(f"torch.mps available: {torch.backends.mps.is_available()}\n")
+
+    after, _ = bfloat_compiles(force_msl32=False)
+    after_forced, _ = bfloat_compiles(force_msl32=True)
+    print(f"bfloat compiles AFTER  import torch (default options): {after}")
+    print(f"bfloat compiles AFTER  import torch (forced MSL 3.2):  {after_forced}")
+
+    print()
+    if before and not after:
+        print(">>> REPRODUCED: importing torch disabled __HAVE_BFLOAT__. <<<")
+    if after and not after_forced:
+        print(">>> unexpected: forcing MSL 3.2 did not restore bfloat. <<<")
+    print()
+    print("Diagnosis: torch's MPS initialisation lowers the Metal device's")
+    print("default shading-language version, so __HAVE_BFLOAT__ is no longer")
+    print("defined for kernels JIT-compiled at runtime -> 'unknown type name")
+    print("bfloat'. Pinning languageVersion = .version3_2 overrides it.")
+    print("Ref: https://github.com/bghira/universal-metal-flash-attention/issues/10")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces several important improvements and new features to the Metal-backed Flash Attention (MFA) bridge and its PyTorch custom op FFI. The main changes include adding full autograd support (forward with log-sum-exp and backward), implementing a Hadamard rotation operator, fixing memory layout and synchronization bugs for PyTorch interop, and updating CI workflow cache actions. Documentation and comments have also been clarified.

**New Features and Functionality:**

* Added autograd support for MFA attention by implementing `mfa_attention_forward_with_lse` (forward with log-sum-exp output) and `mfa_attention_backward` (backward pass for gradients) in both the Swift bridge (`MFABridge.swift`) and the C++/header interface (`metal_sdpa_backend.h`). This enables end-to-end training with PyTorch using the custom op. [[1]](diffhunk://#diff-e6758808fbdf32113d3658ae35987339f99451c6408c9d7aa8dfe9b46e7349d4R2548-R2740) [[2]](diffhunk://#diff-7ef6eefa6cdcf904e78bd500e484674d2e5b1017303152e4f7416dd6ba053442R450-R477)
* Introduced a Hadamard rotation operator (`mfa_hadamard_rotate`) for group-wise Fast Walsh-Hadamard Transform (FWHT), intended for outlier-smoothing before quantized attention. Implemented in Swift and exposed in the C++/header interface. [[1]](diffhunk://#diff-e6758808fbdf32113d3658ae35987339f99451c6408c9d7aa8dfe9b46e7349d4R2885-R2916) [[2]](diffhunk://#diff-7ef6eefa6cdcf904e78bd500e484674d2e5b1017303152e4f7416dd6ba053442R450-R477)

**Bug Fixes and Interop Improvements:**

* Fixed PyTorch interop bugs by ensuring all tensors passed to the Metal kernel are contiguous in memory and synchronizing the MPS command queue before kernel dispatch. This prevents stale or uninitialized data reads due to asynchronous buffer updates.
* Corrected memory layout handling: the MFA kernel now expects and operates directly on [B,H,S,D] (BHSD) layout, so unnecessary permute operations were removed and replaced with `.contiguous()` passthroughs.

**API and Documentation Updates:**

* Updated Swift and C++/header documentation to clarify the expected layouts, precision handling, and autograd API. Suppressed unused parameter warnings and clarified comments for maintainability. [[1]](diffhunk://#diff-e6758808fbdf32113d3658ae35987339f99451c6408c9d7aa8dfe9b46e7349d4L14-R18) [[2]](diffhunk://#diff-e6758808fbdf32113d3658ae35987339f99451c6408c9d7aa8dfe9b46e7349d4L1021-L1034) [[3]](diffhunk://#diff-e6758808fbdf32113d3658ae35987339f99451c6408c9d7aa8dfe9b46e7349d4L1944-R1936) [[4]](diffhunk://#diff-e6758808fbdf32113d3658ae35987339f99451c6408c9d7aa8dfe9b46e7349d4L1961-R1954) [[5]](diffhunk://#diff-e6758808fbdf32113d3658ae35987339f99451c6408c9d7aa8dfe9b46e7349d4L2003-R1996)

**Build and CI Workflow:**

* Updated GitHub Actions workflow to use `actions/cache@v5` instead of `v6` for pre-commit, Swift Package Manager, and pip caches, improving compatibility and stability. (.github/workflows/ci.yml) [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL37-R37) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL68-R68) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL118-R118)

Let me know if you want to see details on the new C API signatures or usage examples for the new autograd or Hadamard rotation features!