### PR TITLE
performance improvement via in-stream processing; correctness fixes for masking; python custom op ffi feature expansion; fused RoPE+Attention caller

### DIFF
--- a/Sources/MFABridge/MFABridge+Quantized.swift
+++ b/Sources/MFABridge/MFABridge+Quantized.swift
@@ -232,6 +232,7 @@ public func mfa_quantized_forward_with_lse(
   _ v: UnsafeMutableRawPointer?,
   _ out: UnsafeMutableRawPointer?,
   _ lse: UnsafeMutableRawPointer?,
+  _ mask: UnsafeMutableRawPointer?,
   _ batchSize: UInt32,
   _ seqLenQ: UInt32,
   _ seqLenKV: UInt32,
@@ -258,6 +259,9 @@ public func mfa_quantized_forward_with_lse(
   let vBuffer = Unmanaged<MFABuffer>.fromOpaque(v).takeUnretainedValue()
   let outBuffer = Unmanaged<MFABuffer>.fromOpaque(out).takeUnretainedValue()
   let lseBuffer = Unmanaged<MFABuffer>.fromOpaque(lse).takeUnretainedValue()
+  let maskBuffer: MFABuffer? = mask.map {
+    Unmanaged<MFABuffer>.fromOpaque($0).takeUnretainedValue()
+  }
 
   let precision = GEMMOperandPrecision(rawValue: UInt16(targetPrecision)) ?? .INT8
   let mode: QuantizationMode = switch quantMode {
@@ -310,6 +314,7 @@ public func mfa_quantized_forward_with_lse(
 
   let quantElemSize = precision.size
   let fp32Size = MemoryLayout<Float>.stride
+  let maskHeadSize = Int(seqLenQ) * Int(seqLenKV) * fp32Size
 
   for batchIdx in 0..<Int(batchSize) {
     for headIdx in 0..<Int(numHeads) {
@@ -318,6 +323,7 @@ public func mfa_quantized_forward_with_lse(
       let vOff = kOff
       let oOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * Int(headDim) * fp32Size
       let lseOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * fp32Size
+      let maskOff = (batchIdx * Int(numHeads) + headIdx) * maskHeadSize
 
       guard
         let cmd = quantAttention.forward(
@@ -325,7 +331,9 @@ public func mfa_quantized_forward_with_lse(
           output: outBuffer.buffer,
           descriptor: quantDescriptor,
           bufferOffsets: (q: qOff, k: kOff, v: vOff, o: oOff, lse: lseOff),
-          externalLogsumexp: lseBuffer.buffer
+          externalLogsumexp: lseBuffer.buffer,
+          mask: maskBuffer?.buffer,
+          maskOffset: maskOff
         )
       else {
         return 5
@@ -360,6 +368,7 @@ public func mfa_quantized_backward(
   _ gradQ: UnsafeMutableRawPointer?,
   _ gradK: UnsafeMutableRawPointer?,
   _ gradV: UnsafeMutableRawPointer?,
+  _ mask: UnsafeMutableRawPointer?,
   _ batchSize: UInt32,
   _ seqLenQ: UInt32,
   _ seqLenKV: UInt32,
@@ -393,6 +402,9 @@ public func mfa_quantized_backward(
   let gradQBuffer = Unmanaged<MFABuffer>.fromOpaque(gradQ).takeUnretainedValue()
   let gradKBuffer = Unmanaged<MFABuffer>.fromOpaque(gradK).takeUnretainedValue()
   let gradVBuffer = Unmanaged<MFABuffer>.fromOpaque(gradV).takeUnretainedValue()
+  let maskBuffer: MFABuffer? = mask.map {
+    Unmanaged<MFABuffer>.fromOpaque($0).takeUnretainedValue()
+  }
 
   let precision = GEMMOperandPrecision(rawValue: UInt16(targetPrecision)) ?? .INT8
   let mode: QuantizationMode = switch quantMode {
@@ -452,6 +464,8 @@ public func mfa_quantized_backward(
     options: .storageModeShared
   )!
 
+  let maskHeadSize = Int(seqLenQ) * Int(seqLenKV) * fp32Size
+
   for batchIdx in 0..<Int(batchSize) {
     for headIdx in 0..<Int(numHeads) {
       let qOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * Int(headDim) * quantElemSize
@@ -463,6 +477,7 @@ public func mfa_quantized_backward(
       let gqOff = oOff
       let gkOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenKV) * Int(headDim) * fp32Size
       let gvOff = gkOff
+      let maskOff = (batchIdx * Int(numHeads) + headIdx) * maskHeadSize
 
       guard
         let cmdBQ = quantAttention.backwardQuery(
@@ -476,15 +491,11 @@ public func mfa_quantized_backward(
           dValues: dBuf,
           descriptor: quantDescriptor,
           bufferOffsets: (
-            q: qOff,
-            k: kOff,
-            v: vOff,
-            o: oOff,
-            go: goOff,
-            lse: lseOff,
-            gq: gqOff,
-            dv: 0
-          )
+            q: qOff, k: kOff, v: vOff, o: oOff,
+            go: goOff, lse: lseOff, gq: gqOff, dv: 0
+          ),
+          mask: maskBuffer?.buffer,
+          maskOffset: maskOff
         )
       else {
         return 5
@@ -509,15 +520,12 @@ public func mfa_quantized_backward(
           gradValue: gradVBuffer.buffer,
           descriptor: quantDescriptor,
           bufferOffsets: (
-            q: qOff,
-            k: kOff,
-            v: vOff,
-            go: goOff,
-            lse: lseOff,
-            dv: 0,
-            gk: gkOff,
-            gv: gvOff
-          )
+            q: qOff, k: kOff, v: vOff,
+            go: goOff, lse: lseOff, dv: 0,
+            gk: gkOff, gv: gvOff
+          ),
+          mask: maskBuffer?.buffer,
+          maskOffset: maskOff
         )
       else {
         return 5

--- a/Sources/MFABridge/MFABridge+Quantized.swift
+++ b/Sources/MFABridge/MFABridge+Quantized.swift
@@ -98,8 +98,8 @@ public func mfa_attention_forward_quantized_direct(
     return 2 // MFA_ERROR_INVALID_ARGUMENT
   }
 
-  // Create multi-head attention with quantization support for proper parallel processing
-  let multiHeadAttention = MultiHeadAttention(device: mfaContext.device)
+  // Use cached multi-head attention instance (reuses compiled pipelines)
+  let multiHeadAttention = mfaContext.multiHeadAttention
 
   // Create proper MultiHeadAttentionDescriptor with 4D shape support
   var baseDescriptor = AttentionDescriptor()
@@ -252,7 +252,6 @@ public func mfa_quantized_forward_with_lse(
   }
 
   let mfaContext = Unmanaged<MFAContext>.fromOpaque(context).takeUnretainedValue()
-  let device = mfaContext.device
 
   let qBuffer = Unmanaged<MFABuffer>.fromOpaque(q).takeUnretainedValue()
   let kBuffer = Unmanaged<MFABuffer>.fromOpaque(k).takeUnretainedValue()
@@ -267,7 +266,7 @@ public func mfa_quantized_forward_with_lse(
   default: .tensorWise
   }
 
-  let quantAttention = QuantizedAttention(device: device)
+  let quantAttention = mfaContext.quantizedAttention
 
   let fullQShape = [Int(batchSize), Int(numHeads), Int(seqLenQ), Int(headDim)]
   let fullKVShape = [Int(batchSize), Int(numHeads), Int(seqLenKV), Int(headDim)]
@@ -402,7 +401,7 @@ public func mfa_quantized_backward(
   default: .tensorWise
   }
 
-  let quantAttention = QuantizedAttention(device: device)
+  let quantAttention = mfaContext.quantizedAttention
 
   let fullQShape = [Int(batchSize), Int(numHeads), Int(seqLenQ), Int(headDim)]
   let fullKVShape = [Int(batchSize), Int(numHeads), Int(seqLenKV), Int(headDim)]
@@ -447,6 +446,12 @@ public func mfa_quantized_backward(
   let quantElemSize = precision.size
   let fp32Size = MemoryLayout<Float>.stride
 
+  // Scratch D buffer — allocated once, reused for all heads.
+  let dBuf = device.makeBuffer(
+    length: Int(seqLenQ) * fp32Size,
+    options: .storageModeShared
+  )!
+
   for batchIdx in 0..<Int(batchSize) {
     for headIdx in 0..<Int(numHeads) {
       let qOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * Int(headDim) * quantElemSize
@@ -458,11 +463,6 @@ public func mfa_quantized_backward(
       let gqOff = oOff
       let gkOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenKV) * Int(headDim) * fp32Size
       let gvOff = gkOff
-
-      let dBuf = device.makeBuffer(
-        length: Int(seqLenQ) * fp32Size,
-        options: .storageModeShared
-      )!
 
       guard
         let cmdBQ = quantAttention.backwardQuery(

--- a/Sources/MFABridge/MFABridge+Quantized.swift
+++ b/Sources/MFABridge/MFABridge+Quantized.swift
@@ -270,7 +270,7 @@ public func mfa_quantized_forward_with_lse(
   default: .tensorWise
   }
 
-  let quantAttention = mfaContext.quantizedAttention
+  let quantAttention = QuantizedAttention(device: mfaContext.device)
 
   let fullQShape = [Int(batchSize), Int(numHeads), Int(seqLenQ), Int(headDim)]
   let fullKVShape = [Int(batchSize), Int(numHeads), Int(seqLenKV), Int(headDim)]
@@ -312,14 +312,18 @@ public func mfa_quantized_forward_with_lse(
     baseDescriptor: baseDescriptor, quantizationConfig: quantConfig
   )
 
-  let quantElemSize = precision.size
+  // INT4 data is packed 2 values per byte; INT8 is 1 byte per value.
+  let quantElemBytes = precision == .INT4
+    ? 0.5 // packed: 2 nibbles per byte
+    : Double(precision.size)
   let fp32Size = MemoryLayout<Float>.stride
   let maskHeadSize = Int(seqLenQ) * Int(seqLenKV) * fp32Size
 
   for batchIdx in 0..<Int(batchSize) {
     for headIdx in 0..<Int(numHeads) {
-      let qOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * Int(headDim) * quantElemSize
-      let kOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenKV) * Int(headDim) * quantElemSize
+      let headIdxFlat = batchIdx * Int(numHeads) + headIdx
+      let qOff = Int(Double(headIdxFlat) * Double(seqLenQ) * Double(headDim) * quantElemBytes)
+      let kOff = Int(Double(headIdxFlat) * Double(seqLenKV) * Double(headDim) * quantElemBytes)
       let vOff = kOff
       let oOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * Int(headDim) * fp32Size
       let lseOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * fp32Size
@@ -413,7 +417,7 @@ public func mfa_quantized_backward(
   default: .tensorWise
   }
 
-  let quantAttention = mfaContext.quantizedAttention
+  let quantAttention = QuantizedAttention(device: mfaContext.device)
 
   let fullQShape = [Int(batchSize), Int(numHeads), Int(seqLenQ), Int(headDim)]
   let fullKVShape = [Int(batchSize), Int(numHeads), Int(seqLenKV), Int(headDim)]
@@ -455,7 +459,9 @@ public func mfa_quantized_backward(
     baseDescriptor: baseDescriptor, quantizationConfig: quantConfig
   )
 
-  let quantElemSize = precision.size
+  let quantElemBytes = precision == .INT4
+    ? 0.5
+    : Double(precision.size)
   let fp32Size = MemoryLayout<Float>.stride
 
   // Scratch D buffer — allocated once, reused for all heads.
@@ -468,8 +474,9 @@ public func mfa_quantized_backward(
 
   for batchIdx in 0..<Int(batchSize) {
     for headIdx in 0..<Int(numHeads) {
-      let qOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * Int(headDim) * quantElemSize
-      let kOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenKV) * Int(headDim) * quantElemSize
+      let headIdxFlat = batchIdx * Int(numHeads) + headIdx
+      let qOff = Int(Double(headIdxFlat) * Double(seqLenQ) * Double(headDim) * quantElemBytes)
+      let kOff = Int(Double(headIdxFlat) * Double(seqLenKV) * Double(headDim) * quantElemBytes)
       let vOff = kOff
       let oOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * Int(headDim) * fp32Size
       let goOff = oOff

--- a/Sources/MFABridge/MFABridge.swift
+++ b/Sources/MFABridge/MFABridge.swift
@@ -894,7 +894,7 @@ public func mfa_attention_forward(
   _ k: UnsafeMutableRawPointer?,
   _ v: UnsafeMutableRawPointer?,
   _ out: UnsafeMutableRawPointer?,
-  _: UInt32,
+  _ batchSize: UInt32,
   _ seqLenQ: UInt32,
   _ seqLenKV: UInt32,
   _ numHeads: UInt32,
@@ -962,7 +962,7 @@ public func mfa_attention_forward(
   do {
     preparedMask = try mfaContext.prepareMask(
       arguments: maskArguments,
-      batchSize: 1,
+      batchSize: batchSize,
       numHeads: numHeads,
       seqLenQ: seqLenQ,
       seqLenKV: seqLenKV
@@ -1002,7 +1002,7 @@ public func mfa_attention_forward(
       kBuffer: kBuffer.buffer,
       vBuffer: vBuffer.buffer,
       outBuffer: outBuffer.buffer,
-      batchSize: 1,
+      batchSize: batchSize,
       seqLenQ: seqLenQ,
       seqLenKV: seqLenKV,
       numHeads: numHeads,

--- a/Sources/MFABridge/MFABridge.swift
+++ b/Sources/MFABridge/MFABridge.swift
@@ -2618,7 +2618,7 @@ public func mfa_attention_forward_with_lse(
   let outBuffer = Unmanaged<MFABuffer>.fromOpaque(out).takeUnretainedValue()
   let lseBuffer = Unmanaged<MFABuffer>.fromOpaque(lse).takeUnretainedValue()
 
-  let multiHeadAttention = mfaContext.multiHeadAttention
+  let multiHeadAttention = MultiHeadAttention(device: mfaContext.device)
 
   var baseDescriptor = AttentionDescriptor()
   baseDescriptor.matrixDimensions = (row: seqLenQ, column: seqLenKV, head: headDim)

--- a/Sources/MFABridge/MFABridge.swift
+++ b/Sources/MFABridge/MFABridge.swift
@@ -200,8 +200,8 @@ final class MFAContext {
         switch (mask_type) {
         case 1u: {
           const device uchar* bool_ptr = mask_raw;
-          bool masked = bool_ptr[linear_index] != 0;
-          mask_value = masked ? -INFINITY : 0.0f;
+          bool attend = bool_ptr[linear_index] != 0;
+          mask_value = attend ? 0.0f : -INFINITY;
           break;
         }
         case 2u: {

--- a/Sources/MFABridge/MFABridge.swift
+++ b/Sources/MFABridge/MFABridge.swift
@@ -305,18 +305,19 @@ final class MFAContext {
       return nil
     }
 
+    // Copy the mask bytes into a device buffer. bytesNoCopy requires a
+    // page-aligned pointer; torch CPU tensors are only malloc-aligned, so
+    // zero-copy wrapping reads garbage (wrong bool masks, NaN additive
+    // masks). Masks are small next to the attention cost — copy is cheap.
     guard
       let maskInputBuffer = device.makeBuffer(
-        bytesNoCopy: arguments.pointer,
+        bytes: arguments.pointer,
         length: arguments.sizeBytes,
-        options: .storageModeShared,
-        deallocator: nil
+        options: .storageModeShared
       )
     else {
       throw MaskPreparationError.bufferAllocationFailed
     }
-
-    maskInputBuffer.didModifyRange(0..<arguments.sizeBytes)
 
     let requiredBytes = totalElements * MemoryLayout<Float>.size
     if maskOutputBuffer == nil || maskOutputBuffer!.length < requiredBytes {
@@ -994,7 +995,7 @@ public func mfa_attention_forward(
     false
   }
 
-  let shouldUseMultiHead = numHeads > 1 && (deviceSupportsMultiHead || forceMultiHead)
+  let shouldUseMultiHead = numHeads >= 1 && (deviceSupportsMultiHead || forceMultiHead)
   if shouldUseMultiHead, deviceSupportsMultiHead {
     return mfa_attention_forward_multihead_internal(
       context: mfaContext,

--- a/Sources/MFABridge/MFABridge.swift
+++ b/Sources/MFABridge/MFABridge.swift
@@ -258,6 +258,90 @@ final class MFAContext {
     case commandExecutionFailed
   }
 
+  // MARK: - RoPE rotation pipeline
+
+  // One static kernel per element type. Applies the interleaved-pair rotary
+  // rotation in fp32 math: out[2i] = x[2i]*cos - x[2i+1]*sin,
+  // out[2i+1] = x[2i+1]*cos + x[2i]*sin, with pair-duplicated tables
+  // (cos[2i] == cos[2i+1]; only the even entry is read). negate_sin = 1
+  // gives the inverse rotation (RoPE is orthonormal), which is exactly the
+  // backward transform for dQ/dK.
+  private static let ropeKernelSource = """
+  #include <metal_stdlib>
+  using namespace metal;
+
+  struct RopeParams {
+    uint B;
+    uint H;
+    uint S;
+    uint D;
+    // Element strides of the (possibly strided) source view.
+    uint src_batch_stride;
+    uint src_head_stride;
+    uint src_seq_stride;
+    // 0 when one table is shared across the batch; S*D for [B, S, D].
+    uint table_batch_stride;
+    uint negate_sin;
+  };
+
+  #define ROPE_KERNEL(NAME, T) \\
+  kernel void NAME( \\
+      device const T* src [[buffer(0)]], \\
+      device T* dst [[buffer(1)]], \\
+      device const float* cos_table [[buffer(2)]], \\
+      device const float* sin_table [[buffer(3)]], \\
+      constant RopeParams& p [[buffer(4)]], \\
+      uint3 tid [[thread_position_in_grid]] \\
+  ) { \\
+    uint pair = tid.x; \\
+    uint s = tid.y; \\
+    uint bh = tid.z; \\
+    if (pair >= p.D / 2 || s >= p.S || bh >= p.B * p.H) return; \\
+    uint b = bh / p.H; \\
+    uint h = bh % p.H; \\
+    ulong src_base = (ulong)b * p.src_batch_stride \\
+                   + (ulong)h * p.src_head_stride \\
+                   + (ulong)s * p.src_seq_stride + pair * 2; \\
+    ulong dst_base = (((ulong)b * p.H + h) * p.S + s) * p.D + pair * 2; \\
+    ulong t = (ulong)b * p.table_batch_stride + (ulong)s * p.D + pair * 2; \\
+    float c = cos_table[t]; \\
+    float sn = sin_table[t]; \\
+    if (p.negate_sin != 0) sn = -sn; \\
+    float x0 = float(src[src_base]); \\
+    float x1 = float(src[src_base + 1]); \\
+    dst[dst_base] = T(x0 * c - x1 * sn); \\
+    dst[dst_base + 1] = T(x1 * c + x0 * sn); \\
+  }
+
+  ROPE_KERNEL(rope_rotate_float, float)
+  ROPE_KERNEL(rope_rotate_half, half)
+  ROPE_KERNEL(rope_rotate_bfloat, bfloat)
+  """
+
+  private var ropePipelines: [String: MTLComputePipelineState] = [:]
+
+  fileprivate func ropePipeline(functionName: String) -> MTLComputePipelineState? {
+    cacheQueue.sync {
+      if let cached = ropePipelines[functionName] {
+        return cached
+      }
+      do {
+        let opts = MTLCompileOptions()
+        opts.languageVersion = .version3_2
+        let library = try device.makeLibrary(source: Self.ropeKernelSource, options: opts)
+        guard let function = library.makeFunction(name: functionName) else {
+          return nil
+        }
+        let pipeline = try device.makeComputePipelineState(function: function)
+        ropePipelines[functionName] = pipeline
+        return pipeline
+      } catch {
+        print("RoPE pipeline creation failed: \\(error)")
+        return nil
+      }
+    }
+  }
+
   private func ensureMaskPipeline() throws -> MTLComputePipelineState {
     if let pipeline = maskPipelineState {
       return pipeline
@@ -402,6 +486,103 @@ final class MFAContext {
       print("Mask kernel execution error: \(error)")
       throw MaskPreparationError.commandExecutionFailed
     }
+
+    return PreparedMask(buffer: outputBuffer)
+  }
+
+  fileprivate func encodePreparedMask(
+    commandBuffer: MTLCommandBuffer,
+    maskBuffer: MTLBuffer?,
+    maskOffset: Int,
+    shape: [Int64],
+    strides: [Int64],
+    ndim: UInt32,
+    type: MaskType,
+    scalarType: MaskScalarType,
+    batchSize: UInt32,
+    numHeads: UInt32,
+    seqLenQ: UInt32,
+    seqLenKV: UInt32
+  ) throws
+    -> PreparedMask?
+  {
+    guard type != .none else {
+      return nil
+    }
+    guard
+      let maskBuffer,
+      !shape.isEmpty,
+      shape.count == strides.count,
+      shape.count == Int(ndim),
+      shape.count <= 4,
+      maskOffset >= 0,
+      maskOffset < maskBuffer.length
+    else {
+      throw MaskPreparationError.invalidMetadata
+    }
+
+    let totalElements = Int(batchSize) * Int(numHeads) * Int(seqLenQ) * Int(seqLenKV)
+    if totalElements == 0 {
+      return nil
+    }
+
+    let requiredBytes = totalElements * MemoryLayout<Float>.size
+    if maskOutputBuffer == nil || maskOutputBuffer!.length < requiredBytes {
+      maskOutputBuffer = device.makeBuffer(length: requiredBytes, options: .storageModeShared)
+    }
+    guard let outputBuffer = maskOutputBuffer else {
+      throw MaskPreparationError.bufferAllocationFailed
+    }
+
+    let pipeline = try ensureMaskPipeline()
+    guard let encoder = commandBuffer.makeComputeCommandEncoder() else {
+      throw MaskPreparationError.commandEncodingFailed
+    }
+
+    encoder.setComputePipelineState(pipeline)
+    encoder.setBuffer(maskBuffer, offset: maskOffset, index: 0)
+    encoder.setBuffer(outputBuffer, offset: 0, index: 1)
+
+    var maskTypeValue = UInt32(type.rawValue)
+    encoder.setBytes(&maskTypeValue, length: MemoryLayout<UInt32>.size, index: 2)
+    var maskScalarValue = UInt32(scalarType.rawValue)
+    encoder.setBytes(&maskScalarValue, length: MemoryLayout<UInt32>.size, index: 3)
+
+    let shapeVector: [UInt32] = [batchSize, numHeads, seqLenQ, seqLenKV]
+    shapeVector.withUnsafeBytes { bytes in
+      if let baseAddress = bytes.baseAddress {
+        encoder.setBytes(baseAddress, length: bytes.count, index: 4)
+      }
+    }
+
+    var elementCount = UInt32(totalElements)
+    encoder.setBytes(&elementCount, length: MemoryLayout<UInt32>.size, index: 5)
+
+    var maskDims = UInt32(ndim)
+    encoder.setBytes(&maskDims, length: MemoryLayout<UInt32>.size, index: 6)
+
+    shape.withUnsafeBytes { bytes in
+      if let baseAddress = bytes.baseAddress {
+        encoder.setBytes(baseAddress, length: bytes.count, index: 7)
+      }
+    }
+    strides.withUnsafeBytes { bytes in
+      if let baseAddress = bytes.baseAddress {
+        encoder.setBytes(baseAddress, length: bytes.count, index: 8)
+      }
+    }
+
+    let maxThreads = pipeline.maxTotalThreadsPerThreadgroup
+    let threadsPerGroup = min(maxThreads, 256)
+    let threadgroupSize = MTLSize(width: threadsPerGroup, height: 1, depth: 1)
+    let threadgroupCount = MTLSize(
+      width: (totalElements + threadsPerGroup - 1) / threadsPerGroup,
+      height: 1,
+      depth: 1
+    )
+
+    encoder.dispatchThreadgroups(threadgroupCount, threadsPerThreadgroup: threadgroupSize)
+    encoder.endEncoding()
 
     return PreparedMask(buffer: outputBuffer)
   }
@@ -1054,10 +1235,11 @@ public func mfa_attention_forward(
       // Set custom scale factor - this fixes the root cause of the correctness issue
       descriptor.softmaxScale = softmaxScale
 
-      // Always use FP32 inputs — the C++ backend promotes fp16/bf16 to fp32
-      // before calling the kernel, so the kernel always receives fp32 data.
-      descriptor.lowPrecisionInputs = false
-      descriptor.lowPrecisionIntermediates = false
+      configureAttentionPrecision(
+        &descriptor,
+        inputPrecision: inputPrecision,
+        intermediatePrecision: intermediatePrecision
+      )
 
       // Create kernel descriptor
       let kernelDescriptor = descriptor.kernelDescriptor(type: .forward)
@@ -1261,6 +1443,29 @@ private func parsePrecisionString(_ precisionStr: UnsafePointer<CChar>?) -> Int3
   case "int4": return 4 // MFA_PRECISION_INT4 = 4
   default: return 2 // Default to FP32 (C FFI value = 2)
   }
+}
+
+private func gemmPrecision(fromMFAPrecision precision: Int32) -> GEMMOperandPrecision {
+  switch precision {
+  case 0:
+    .FP16
+  case 1:
+    .BF16
+  default:
+    .FP32
+  }
+}
+
+private func configureAttentionPrecision(
+  _ descriptor: inout AttentionDescriptor,
+  inputPrecision: Int32,
+  intermediatePrecision: Int32
+) {
+  let input = gemmPrecision(fromMFAPrecision: inputPrecision)
+  let intermediate = gemmPrecision(fromMFAPrecision: intermediatePrecision)
+  descriptor.inputMemoryPrecision = input
+  descriptor.lowPrecisionInputs = input != .FP32
+  descriptor.lowPrecisionIntermediates = intermediate != .FP32
 }
 
 @_cdecl("mfa_attention_forward_str")
@@ -1968,8 +2173,8 @@ private func mfa_attention_forward_multihead_internal(
   headDim: UInt16,
   softmaxScale: Float,
   causal: Bool,
-  inputPrecision _: Int32,
-  intermediatePrecision _: Int32,
+  inputPrecision: Int32,
+  intermediatePrecision: Int32,
   transposeQ: Bool,
   transposeK: Bool,
   transposeV: Bool,
@@ -1986,9 +2191,11 @@ private func mfa_attention_forward_multihead_internal(
   var baseDescriptor = AttentionDescriptor()
   baseDescriptor.matrixDimensions = (row: seqLenQ, column: seqLenKV, head: headDim)
 
-  // Always FP32 inputs — the C++ backend promotes fp16/bf16 to fp32.
-  baseDescriptor.lowPrecisionInputs = false
-  baseDescriptor.lowPrecisionIntermediates = false
+  configureAttentionPrecision(
+    &baseDescriptor,
+    inputPrecision: inputPrecision,
+    intermediatePrecision: intermediatePrecision
+  )
   baseDescriptor.transposeState = (Q: transposeQ, K: transposeK, V: transposeV, O: transposeO)
   baseDescriptor.sparsityPattern = causal ? .causal : .none
   baseDescriptor.softmaxScale = softmaxScale
@@ -2053,6 +2260,281 @@ private func mfa_attention_forward_multihead_internal(
   GlobalContextStore.shared.updateLatency(gpuLatency)
 
   return 0 // MFA_SUCCESS
+}
+
+/// Encode attention into a caller-provided MTLCommandBuffer without
+/// committing or waiting. The caller owns submission and completion — when
+/// that command buffer belongs to PyTorch's MPS stream, ordering against the
+/// surrounding tensor ops is automatic and no host synchronization is needed.
+///
+/// All buffer arguments are raw `id<MTLBuffer>` pointers (not mfa_buffer_t
+/// wrappers); offsets are in bytes. Optional mask buffers are raw MTLBuffers
+/// too and are expanded into the additive FP32 mask buffer on the same command
+/// buffer before attention is encoded. Causal masking via the IS_CAUSAL
+/// function constant is also supported.
+/// Encode a RoPE rotation into a caller-provided command buffer without
+/// committing or waiting. src may be a strided BHSD view (element strides,
+/// last dim contiguous); dst is a dense BHSD buffer of the same dtype.
+/// Tables are fp32, pair-duplicated, laid out [S, D] with an optional batch
+/// stride (0 = shared across batch). negateSin selects the inverse rotation
+/// (the dQ/dK backward transform).
+@_cdecl("mfa_rope_rotate_encode_mtl")
+public func mfa_rope_rotate_encode_mtl(
+  _ context: UnsafeMutableRawPointer?,
+  _ commandBuffer: UnsafeMutableRawPointer?,
+  _ src: UnsafeMutableRawPointer?,
+  _ srcOffset: Int,
+  _ srcBatchStride: Int64,
+  _ srcHeadStride: Int64,
+  _ srcSeqStride: Int64,
+  _ dst: UnsafeMutableRawPointer?,
+  _ dstOffset: Int,
+  _ cosTable: UnsafeMutableRawPointer?,
+  _ cosOffset: Int,
+  _ sinTable: UnsafeMutableRawPointer?,
+  _ sinOffset: Int,
+  _ tableBatchStride: Int64,
+  _ negateSin: Bool,
+  _ batchSize: UInt32,
+  _ numHeads: UInt32,
+  _ seqLen: UInt32,
+  _ headDim: UInt32,
+  _ precisionStr: UnsafePointer<CChar>?
+)
+  -> Int32
+{
+  guard let context, let commandBuffer, let src, let dst, let cosTable, let sinTable else {
+    return 1 // MFA_ERROR_INVALID_ARGS
+  }
+  let mfaContext = Unmanaged<MFAContext>.fromOpaque(context).takeUnretainedValue()
+  guard
+    let cb = Unmanaged<AnyObject>.fromOpaque(commandBuffer).takeUnretainedValue()
+    as? MTLCommandBuffer,
+    let srcBuf = Unmanaged<AnyObject>.fromOpaque(src).takeUnretainedValue() as? MTLBuffer,
+    let dstBuf = Unmanaged<AnyObject>.fromOpaque(dst).takeUnretainedValue() as? MTLBuffer,
+    let cosBuf = Unmanaged<AnyObject>.fromOpaque(cosTable).takeUnretainedValue() as? MTLBuffer,
+    let sinBuf = Unmanaged<AnyObject>.fromOpaque(sinTable).takeUnretainedValue() as? MTLBuffer
+  else {
+    return 1 // MFA_ERROR_INVALID_ARGS
+  }
+
+  let functionName = switch parsePrecisionString(precisionStr) {
+  case 0: "rope_rotate_half"
+  case 1: "rope_rotate_bfloat"
+  default: "rope_rotate_float"
+  }
+  guard let pipeline = mfaContext.ropePipeline(functionName: functionName) else {
+    return 4 // MFA_ERROR_KERNEL_COMPILATION
+  }
+  guard let encoder = cb.makeComputeCommandEncoder() else {
+    return 5 // MFA_ERROR_EXECUTION_FAILED
+  }
+
+  struct RopeParams {
+    var B: UInt32
+    var H: UInt32
+    var S: UInt32
+    var D: UInt32
+    var srcBatchStride: UInt32
+    var srcHeadStride: UInt32
+    var srcSeqStride: UInt32
+    var tableBatchStride: UInt32
+    var negateSin: UInt32
+  }
+  var params = RopeParams(
+    B: batchSize, H: numHeads, S: seqLen, D: headDim,
+    srcBatchStride: UInt32(truncatingIfNeeded: srcBatchStride),
+    srcHeadStride: UInt32(truncatingIfNeeded: srcHeadStride),
+    srcSeqStride: UInt32(truncatingIfNeeded: srcSeqStride),
+    tableBatchStride: UInt32(truncatingIfNeeded: tableBatchStride),
+    negateSin: negateSin ? 1 : 0
+  )
+
+  encoder.setComputePipelineState(pipeline)
+  encoder.setBuffer(srcBuf, offset: srcOffset, index: 0)
+  encoder.setBuffer(dstBuf, offset: dstOffset, index: 1)
+  encoder.setBuffer(cosBuf, offset: cosOffset, index: 2)
+  encoder.setBuffer(sinBuf, offset: sinOffset, index: 3)
+  encoder.setBytes(&params, length: MemoryLayout<RopeParams>.size, index: 4)
+
+  let grid = MTLSize(
+    width: Int(headDim / 2),
+    height: Int(seqLen),
+    depth: Int(batchSize * numHeads)
+  )
+  let w = min(pipeline.threadExecutionWidth, Int(headDim / 2))
+  let group = MTLSize(width: max(w, 1), height: 1, depth: 1)
+  encoder.dispatchThreads(grid, threadsPerThreadgroup: group)
+  encoder.endEncoding()
+  return 0 // MFA_SUCCESS
+}
+
+@_cdecl("mfa_attention_encode_mtl")
+public func mfa_attention_encode_mtl(
+  _ context: UnsafeMutableRawPointer?,
+  _ commandBuffer: UnsafeMutableRawPointer?,
+  _ q: UnsafeMutableRawPointer?,
+  _ qOffset: Int,
+  _ qStrides: UnsafePointer<Int64>?,
+  _ k: UnsafeMutableRawPointer?,
+  _ kOffset: Int,
+  _ kStrides: UnsafePointer<Int64>?,
+  _ v: UnsafeMutableRawPointer?,
+  _ vOffset: Int,
+  _ vStrides: UnsafePointer<Int64>?,
+  _ out: UnsafeMutableRawPointer?,
+  _ outOffset: Int,
+  _ mask: UnsafeMutableRawPointer?,
+  _ maskOffset: Int,
+  _ maskShape: UnsafePointer<Int64>?,
+  _ maskStrides: UnsafePointer<Int64>?,
+  _ maskNDim: UInt32,
+  _ maskTypeRaw: Int32,
+  _ maskScalarTypeRaw: Int32,
+  _ batchSize: UInt32,
+  _ seqLenQ: UInt32,
+  _ seqLenKV: UInt32,
+  _ numHeads: UInt32,
+  _ headDim: UInt16,
+  _ softmaxScale: Float,
+  _ causal: Bool,
+  _ inputPrecisionStr: UnsafePointer<CChar>?,
+  _ intermediatePrecisionStr: UnsafePointer<CChar>?
+)
+  -> Int32
+{
+  guard let context, let commandBuffer, let q, let k, let v, let out else {
+    return 1 // MFA_ERROR_INVALID_ARGS
+  }
+  let mfaContext = Unmanaged<MFAContext>.fromOpaque(context).takeUnretainedValue()
+  guard
+    let cb = Unmanaged<AnyObject>.fromOpaque(commandBuffer).takeUnretainedValue()
+    as? MTLCommandBuffer,
+    let qBuf = Unmanaged<AnyObject>.fromOpaque(q).takeUnretainedValue() as? MTLBuffer,
+    let kBuf = Unmanaged<AnyObject>.fromOpaque(k).takeUnretainedValue() as? MTLBuffer,
+    let vBuf = Unmanaged<AnyObject>.fromOpaque(v).takeUnretainedValue() as? MTLBuffer,
+    let outBuf = Unmanaged<AnyObject>.fromOpaque(out).takeUnretainedValue() as? MTLBuffer
+  else {
+    return 1 // MFA_ERROR_INVALID_ARGS
+  }
+
+  let resolvedMaskType = MaskType(rawValue: maskTypeRaw) ?? .none
+  let resolvedMaskScalar = MaskScalarType(rawValue: maskScalarTypeRaw) ?? .byte
+  let maskBuffer: MTLBuffer?
+  let maskShapeArray: [Int64]
+  let maskStrideArray: [Int64]
+  if resolvedMaskType != .none {
+    guard
+      let mask,
+      let maskShape,
+      let maskStrides,
+      maskNDim > 0,
+      let mtlMask = Unmanaged<AnyObject>.fromOpaque(mask).takeUnretainedValue() as? MTLBuffer
+    else {
+      return 1 // MFA_ERROR_INVALID_ARGS
+    }
+    maskBuffer = mtlMask
+    maskShapeArray = Array(UnsafeBufferPointer(start: maskShape, count: Int(maskNDim)))
+    maskStrideArray = Array(UnsafeBufferPointer(start: maskStrides, count: Int(maskNDim)))
+  } else {
+    maskBuffer = nil
+    maskShapeArray = []
+    maskStrideArray = []
+  }
+
+  var baseDescriptor = AttentionDescriptor()
+  baseDescriptor.matrixDimensions = (row: seqLenQ, column: seqLenKV, head: headDim)
+  configureAttentionPrecision(
+    &baseDescriptor,
+    inputPrecision: parsePrecisionString(inputPrecisionStr),
+    intermediatePrecision: parsePrecisionString(intermediatePrecisionStr)
+  )
+  baseDescriptor.transposeState = (Q: false, K: false, V: false, O: false)
+  baseDescriptor.sparsityPattern = causal ? .causal : .none
+  baseDescriptor.softmaxScale = softmaxScale
+
+  let queryShape = MultiHeadShape(
+    batchSize: batchSize,
+    numHeads: numHeads,
+    sequenceLength: seqLenQ,
+    headDimension: headDim
+  )
+  let kvShape = MultiHeadShape(
+    batchSize: batchSize,
+    numHeads: numHeads,
+    sequenceLength: seqLenKV,
+    headDimension: headDim
+  )
+  let multiHeadDescriptor = MultiHeadAttentionDescriptor(
+    baseDescriptor: baseDescriptor,
+    queryShape: queryShape,
+    keyShape: kvShape,
+    valueShape: kvShape,
+    broadcastMode: .standard,
+    dispatchStrategy: .perBatch
+  )
+
+  let preparedMask: PreparedMask?
+  do {
+    preparedMask = try mfaContext.encodePreparedMask(
+      commandBuffer: cb,
+      maskBuffer: maskBuffer,
+      maskOffset: maskOffset,
+      shape: maskShapeArray,
+      strides: maskStrideArray,
+      ndim: maskNDim,
+      type: resolvedMaskType,
+      scalarType: resolvedMaskScalar,
+      batchSize: batchSize,
+      numHeads: numHeads,
+      seqLenQ: seqLenQ,
+      seqLenKV: seqLenKV
+    )
+  } catch let maskError as MFAContext.MaskPreparationError {
+    switch maskError {
+    case .invalidMetadata:
+      return 1
+    case .pipelineCreationFailed:
+      return 4
+    case .bufferAllocationFailed:
+      return 2
+    case .commandEncodingFailed, .commandExecutionFailed:
+      return 5
+    }
+  } catch {
+    return 5
+  }
+
+  // The cached instance is safe now that MultiHeadAttention's pipeline
+  // cache keys include the function-constant inputs (dimensions, sparsity).
+  // The historical NaN-with-cached-instance bug was shape-collision in that
+  // cache — pipelines compiled for one shape were reused for another. The
+  // encode path never touches the instance's own command queue.
+  // Q/K/V strides: ELEMENT strides in BHSD order (4 entries) or null for
+  // contiguous tensors. The last dim must be contiguous (stride 1).
+  func strideArray(_ p: UnsafePointer<Int64>?) -> [Int64]? {
+    guard let p else { return nil }
+    return Array(UnsafeBufferPointer(start: p, count: 4))
+  }
+
+  let encoded = mfaContext.multiHeadAttention.encodeForward(
+    commandBuffer: cb,
+    query: qBuf,
+    key: kBuf,
+    value: vBuf,
+    output: outBuf,
+    queryOffset: qOffset,
+    keyOffset: kOffset,
+    valueOffset: vOffset,
+    outputOffset: outOffset,
+    queryStrides: strideArray(qStrides),
+    keyStrides: strideArray(kStrides),
+    valueStrides: strideArray(vStrides),
+    logsumexp: nil,
+    descriptor: multiHeadDescriptor,
+    maskBuffer: preparedMask?.buffer
+  )
+  return encoded ? 0 : 5 // MFA_SUCCESS : MFA_ERROR_EXECUTION_FAILED
 }
 
 /// Helper function to dequantize buffers for MultiHeadAttention processing
@@ -2601,6 +3083,8 @@ public func mfa_attention_forward_with_lse(
   _ headDim: UInt16,
   _ softmaxScale: Float,
   _ causal: Bool,
+  _ inputPrecision: Int32,
+  _ intermediatePrecision: Int32,
   _ transposeQ: Bool,
   _ transposeK: Bool,
   _ transposeV: Bool,
@@ -2623,8 +3107,11 @@ public func mfa_attention_forward_with_lse(
 
   var baseDescriptor = AttentionDescriptor()
   baseDescriptor.matrixDimensions = (row: seqLenQ, column: seqLenKV, head: headDim)
-  baseDescriptor.lowPrecisionInputs = false
-  baseDescriptor.lowPrecisionIntermediates = false
+  configureAttentionPrecision(
+    &baseDescriptor,
+    inputPrecision: inputPrecision,
+    intermediatePrecision: intermediatePrecision
+  )
   baseDescriptor.transposeState = (Q: transposeQ, K: transposeK, V: transposeV, O: transposeO)
   baseDescriptor.sparsityPattern = causal ? .causal : .none
   baseDescriptor.softmaxScale = softmaxScale
@@ -2694,6 +3181,8 @@ public func mfa_attention_backward(
   _ headDim: UInt16,
   _ softmaxScale: Float,
   _ causal: Bool,
+  _ inputPrecision: Int32,
+  _ intermediatePrecision: Int32,
   _ transposeQ: Bool,
   _ transposeK: Bool,
   _ transposeV: Bool,
@@ -2725,8 +3214,11 @@ public func mfa_attention_backward(
 
   var baseDescriptor = AttentionDescriptor()
   baseDescriptor.matrixDimensions = (row: seqLenQ, column: seqLenKV, head: headDim)
-  baseDescriptor.lowPrecisionInputs = false
-  baseDescriptor.lowPrecisionIntermediates = false
+  configureAttentionPrecision(
+    &baseDescriptor,
+    inputPrecision: inputPrecision,
+    intermediatePrecision: intermediatePrecision
+  )
   baseDescriptor.transposeState = (Q: transposeQ, K: transposeK, V: transposeV, O: transposeO)
   baseDescriptor.sparsityPattern = causal ? .causal : .none
   baseDescriptor.softmaxScale = softmaxScale

--- a/Sources/MFABridge/MFABridge.swift
+++ b/Sources/MFABridge/MFABridge.swift
@@ -101,6 +101,41 @@ final class MFAContext {
   private var lBufferCache: [UInt32: MTLBuffer] = [:]
   private var dBufferCache: [UInt32: MTLBuffer] = [:]
 
+  // Cached attention instances — created once, reused across all FFI calls.
+  // Each instance holds its own pipelineCache and MTLCommandQueue; caching
+  // prevents per-call kernel recompilation (the main source of GPU memory
+  // growth on constrained runners).
+  private var _multiHeadAttention: MultiHeadAttention?
+  private var _quantizedAttention: QuantizedAttention?
+  private var _hadamardRotation: HadamardRotation?
+
+  var multiHeadAttention: MultiHeadAttention {
+    cacheQueue.sync {
+      if _multiHeadAttention == nil {
+        _multiHeadAttention = MultiHeadAttention(device: device)
+      }
+      return _multiHeadAttention!
+    }
+  }
+
+  var quantizedAttention: QuantizedAttention {
+    cacheQueue.sync {
+      if _quantizedAttention == nil {
+        _quantizedAttention = QuantizedAttention(device: device)
+      }
+      return _quantizedAttention!
+    }
+  }
+
+  var hadamardRotation: HadamardRotation {
+    cacheQueue.sync {
+      if _hadamardRotation == nil {
+        _hadamardRotation = HadamardRotation(device: device)
+      }
+      return _hadamardRotation!
+    }
+  }
+
   /// Store GPU timing for zero-overhead measurement
   var lastGPULatency: CFTimeInterval = 0.0
 
@@ -1613,7 +1648,7 @@ public func mfa_attention_backward_query_quantized_ex(
     quantizationConfig: quantConfig
   )
 
-  let quantizedAttention = QuantizedAttention(device: device)
+  let quantizedAttention = mfaContext.quantizedAttention
 
   guard
     let commandBuffer = quantizedAttention.backwardQuery(
@@ -1884,7 +1919,7 @@ public func mfa_attention_backward_kv_quantized_ex(
     quantizationConfig: quantConfig
   )
 
-  let quantizedAttention = QuantizedAttention(device: device)
+  let quantizedAttention = mfaContext.quantizedAttention
 
   guard
     let commandBuffer = quantizedAttention.backwardKeyValue(
@@ -1942,7 +1977,8 @@ private func mfa_attention_forward_multihead_internal(
 )
   -> Int32
 {
-  // Create multi-head attention instance
+  // Create per-call instance — the cached instance causes NaN in causal
+  // masking tests due to commandQueue state accumulation.
   let multiHeadAttention = MultiHeadAttention(device: context.device)
 
   // Create base attention descriptor
@@ -2582,7 +2618,7 @@ public func mfa_attention_forward_with_lse(
   let outBuffer = Unmanaged<MFABuffer>.fromOpaque(out).takeUnretainedValue()
   let lseBuffer = Unmanaged<MFABuffer>.fromOpaque(lse).takeUnretainedValue()
 
-  let multiHeadAttention = MultiHeadAttention(device: mfaContext.device)
+  let multiHeadAttention = mfaContext.multiHeadAttention
 
   var baseDescriptor = AttentionDescriptor()
   baseDescriptor.matrixDimensions = (row: seqLenQ, column: seqLenKV, head: headDim)
@@ -2684,7 +2720,7 @@ public func mfa_attention_backward(
   let dvBuf = Unmanaged<MFABuffer>.fromOpaque(dv).takeUnretainedValue()
   let dScratchBuf = Unmanaged<MFABuffer>.fromOpaque(dBuffer).takeUnretainedValue()
 
-  let multiHeadAttention = MultiHeadAttention(device: mfaContext.device)
+  let multiHeadAttention = mfaContext.multiHeadAttention
 
   var baseDescriptor = AttentionDescriptor()
   baseDescriptor.matrixDimensions = (row: seqLenQ, column: seqLenKV, head: headDim)
@@ -2905,8 +2941,8 @@ public func mfa_hadamard_rotate(
   guard let data else { return 1 }
   guard blockSize > 0, numBlocks > 0 else { return 1 }
 
-  let dev = MTLCreateSystemDefaultDevice()!
-  let rotator = HadamardRotation(device: dev)
+  guard let mfaContext = GlobalContextStore.shared.context() else { return 1 }
+  let rotator = mfaContext.hadamardRotation
   let buffer = Unmanaged<MFABuffer>.fromOpaque(data).takeUnretainedValue()
 
   do {

--- a/Sources/MFABridge/include/mfa_ffi.h
+++ b/Sources/MFABridge/include/mfa_ffi.h
@@ -252,6 +252,39 @@ mfa_error_t mfa_attention_forward(
     bool transpose_o
 );
 
+/**
+ * @brief Encode attention into a caller-provided MTLCommandBuffer.
+ *
+ * Does not commit or wait — the caller owns submission and completion.
+ * Intended for encoding into an external stream (e.g. PyTorch's MPS stream)
+ * so no host synchronization is required around the dispatch. Buffers are
+ * raw id<MTLBuffer> pointers; offsets are in bytes. Optional masks are raw
+ * id<MTLBuffer> pointers plus tensor metadata and are expanded on the same
+ * command buffer before attention; causal masking is also supported.
+ */
+mfa_error_t mfa_attention_encode_mtl(
+    mfa_context_t context,
+    void* command_buffer,
+    void* q_buffer, int64_t q_offset, const int64_t* q_strides,
+    void* k_buffer, int64_t k_offset, const int64_t* k_strides,
+    void* v_buffer, int64_t v_offset, const int64_t* v_strides,
+    void* out_buffer, int64_t out_offset,
+    void* mask_buffer, int64_t mask_offset,
+    const int64_t* mask_shape,
+    const int64_t* mask_strides,
+    uint32_t mask_ndim,
+    mfa_mask_type_t mask_type,
+    mfa_mask_scalar_t mask_scalar_type,
+    uint32_t batch_size,
+    uint32_t seq_len_q,
+    uint32_t seq_len_kv,
+    uint32_t num_heads,
+    uint16_t head_dim,
+    float softmax_scale,
+    bool causal,
+    const char* input_precision,
+    const char* intermediate_precision
+);
 
 mfa_error_t mfa_attention_backward(
     mfa_context_t context,
@@ -266,6 +299,7 @@ mfa_error_t mfa_attention_backward(
     mfa_buffer_t dq,          // Gradient w.r.t Q
     mfa_buffer_t dk,          // Gradient w.r.t K
     mfa_buffer_t dv,          // Gradient w.r.t V
+    mfa_buffer_t d_buffer,    // Scratch buffer [batch_size * num_heads * seq_len_q]
     // Dimensions
     uint32_t batch_size,
     uint32_t seq_len_q,
@@ -278,7 +312,6 @@ mfa_error_t mfa_attention_backward(
     // Precision control
     mfa_precision_t input_precision,
     mfa_precision_t intermediate_precision,
-    mfa_precision_t output_precision,
     // Layout control
     bool transpose_q,
     bool transpose_k,

--- a/Sources/MFAFFI/include/mfa_ffi.h
+++ b/Sources/MFAFFI/include/mfa_ffi.h
@@ -300,6 +300,40 @@ mfa_error_t mfa_attention_forward(
 );
 
 /**
+ * @brief Encode attention into a caller-provided MTLCommandBuffer.
+ *
+ * Does not commit or wait — the caller owns submission and completion.
+ * Intended for encoding into an external stream (e.g. PyTorch's MPS stream)
+ * so no host synchronization is required around the dispatch. Buffers are
+ * raw id<MTLBuffer> pointers; offsets are in bytes. Optional masks are raw
+ * id<MTLBuffer> pointers plus tensor metadata and are expanded on the same
+ * command buffer before attention; causal masking is also supported.
+ */
+mfa_error_t mfa_attention_encode_mtl(
+    mfa_context_t context,
+    void* command_buffer,
+    void* q_buffer, int64_t q_offset, const int64_t* q_strides,
+    void* k_buffer, int64_t k_offset, const int64_t* k_strides,
+    void* v_buffer, int64_t v_offset, const int64_t* v_strides,
+    void* out_buffer, int64_t out_offset,
+    void* mask_buffer, int64_t mask_offset,
+    const int64_t* mask_shape,
+    const int64_t* mask_strides,
+    uint32_t mask_ndim,
+    mfa_mask_type_t mask_type,
+    mfa_mask_scalar_t mask_scalar_type,
+    uint32_t batch_size,
+    uint32_t seq_len_q,
+    uint32_t seq_len_kv,
+    uint32_t num_heads,
+    uint16_t head_dim,
+    float softmax_scale,
+    bool causal,
+    const char* input_precision,
+    const char* intermediate_precision
+);
+
+/**
  * @brief Perform Quantized Flash Attention forward pass
  *
  * Computes scaled dot-product attention with quantized K/V tensors for memory efficiency.
@@ -383,6 +417,7 @@ mfa_error_t mfa_attention_backward(
     mfa_buffer_t dq,          // Gradient w.r.t Q
     mfa_buffer_t dk,          // Gradient w.r.t K
     mfa_buffer_t dv,          // Gradient w.r.t V
+    mfa_buffer_t d_buffer,    // Scratch buffer [batch_size * num_heads * seq_len_q]
     // Dimensions
     uint32_t batch_size,
     uint32_t seq_len_q,
@@ -395,7 +430,6 @@ mfa_error_t mfa_attention_backward(
     // Precision control
     mfa_precision_t input_precision,
     mfa_precision_t intermediate_precision,
-    mfa_precision_t output_precision,
     // Layout control
     bool transpose_q,
     bool transpose_k,

--- a/Tests/MFAFFITests/MultiHeadFFITests.swift
+++ b/Tests/MFAFFITests/MultiHeadFFITests.swift
@@ -164,9 +164,16 @@ final class MultiHeadFFITests: XCTestCase {
 
     // Generate deterministic test data for reproducibility
     let seed: UInt64 = 42
-    var queryData = generateDeterministicData(count: totalElements, seed: seed)
-    var keyData = generateDeterministicData(count: totalElements, seed: seed + 1)
-    var valueData = generateDeterministicData(count: totalElements, seed: seed + 2)
+    let queryData = generateDeterministicData(count: totalElements, seed: seed)
+    let keyData = generateDeterministicData(count: totalElements, seed: seed + 1)
+    let valueData = generateDeterministicData(count: totalElements, seed: seed + 2)
+
+    // Input precision is honored by the kernels: buffers must contain data
+    // in the declared memory format. The output is always FP32 (the kernel
+    // stores O as FP32 regardless of the output precision label).
+    var queryBytes = encodeInputData(queryData, precision: inputPrecision)
+    var keyBytes = encodeInputData(keyData, precision: inputPrecision)
+    var valueBytes = encodeInputData(valueData, precision: inputPrecision)
     var outputData = [Float](repeating: 0.0, count: totalElements)
 
     // Create MFA buffers
@@ -175,20 +182,21 @@ final class MultiHeadFFITests: XCTestCase {
     var vBuffer: UnsafeMutableRawPointer?
     var oBuffer: UnsafeMutableRawPointer?
 
-    let dataSize = totalElements * MemoryLayout<Float>.size
+    let inputSize = queryBytes.count
+    let outputSize = totalElements * MemoryLayout<Float>.size
 
     // Create buffers from existing data
-    let result1 = queryData.withUnsafeMutableBytes { ptr in
-      mfa_buffer_from_ptr(context, ptr.baseAddress, dataSize, &qBuffer)
+    let result1 = queryBytes.withUnsafeMutableBytes { ptr in
+      mfa_buffer_from_ptr(context, ptr.baseAddress, inputSize, &qBuffer)
     }
-    let result2 = keyData.withUnsafeMutableBytes { ptr in
-      mfa_buffer_from_ptr(context, ptr.baseAddress, dataSize, &kBuffer)
+    let result2 = keyBytes.withUnsafeMutableBytes { ptr in
+      mfa_buffer_from_ptr(context, ptr.baseAddress, inputSize, &kBuffer)
     }
-    let result3 = valueData.withUnsafeMutableBytes { ptr in
-      mfa_buffer_from_ptr(context, ptr.baseAddress, dataSize, &vBuffer)
+    let result3 = valueBytes.withUnsafeMutableBytes { ptr in
+      mfa_buffer_from_ptr(context, ptr.baseAddress, inputSize, &vBuffer)
     }
     let result4 = outputData.withUnsafeMutableBytes { ptr in
-      mfa_buffer_from_ptr(context, ptr.baseAddress, dataSize, &oBuffer)
+      mfa_buffer_from_ptr(context, ptr.baseAddress, outputSize, &oBuffer)
     }
 
     guard
@@ -592,6 +600,40 @@ final class MultiHeadFFITests: XCTestCase {
     }
   }
 
+  /// Encode fp32 test values into the memory format a precision label
+  /// declares. The FFI honors input precision, so fp32 bytes labeled
+  /// fp16/bf16 would be reinterpreted as garbage.
+  private func encodeInputData(_ data: [Float], precision: mfa_precision_t) -> [UInt8] {
+    switch precision {
+    case mfa_precision_t(0): // FP16
+      var out = [UInt8]()
+      out.reserveCapacity(data.count * 2)
+      for value in data {
+        let half = Float16(value)
+        withUnsafeBytes(of: half) { out.append(contentsOf: $0) }
+      }
+      return out
+    case mfa_precision_t(1): // BF16, round-to-nearest-even
+      var out = [UInt8]()
+      out.reserveCapacity(data.count * 2)
+      for value in data {
+        var bits = value.bitPattern
+        let lsb = (bits >> 16) & 1
+        bits = bits &+ 0x7FFF &+ lsb
+        let bf16 = UInt16(truncatingIfNeeded: bits >> 16)
+        withUnsafeBytes(of: bf16) { out.append(contentsOf: $0) }
+      }
+      return out
+    default: // FP32
+      var out = [UInt8]()
+      out.reserveCapacity(data.count * 4)
+      for value in data {
+        withUnsafeBytes(of: value) { out.append(contentsOf: $0) }
+      }
+      return out
+    }
+  }
+
   private func testSingleHeadConfiguration(
     numHeads: UInt32,
     seqLen: UInt32,
@@ -608,9 +650,17 @@ final class MultiHeadFFITests: XCTestCase {
 
     // Use deterministic data for reproducibility
     let seed = deterministicSeed(for: testName)
-    var queryData = generateDeterministicData(count: totalElements, seed: seed)
-    var keyData = generateDeterministicData(count: totalElements, seed: seed + 1)
-    var valueData = generateDeterministicData(count: totalElements, seed: seed + 2)
+    let queryData = generateDeterministicData(count: totalElements, seed: seed)
+    let keyData = generateDeterministicData(count: totalElements, seed: seed + 1)
+    let valueData = generateDeterministicData(count: totalElements, seed: seed + 2)
+
+    // Input precision is honored by the kernels: buffers must contain data
+    // in the memory format the precision label declares. The output is
+    // always FP32 (the kernel stores O as FP32 regardless of the output
+    // precision label).
+    var queryBytes = encodeInputData(queryData, precision: inputPrecision)
+    var keyBytes = encodeInputData(keyData, precision: inputPrecision)
+    var valueBytes = encodeInputData(valueData, precision: inputPrecision)
     var outputData = [Float](repeating: 0.0, count: totalElements)
 
     // Create MFA buffers
@@ -619,19 +669,20 @@ final class MultiHeadFFITests: XCTestCase {
     var vBuffer: UnsafeMutableRawPointer?
     var oBuffer: UnsafeMutableRawPointer?
 
-    let dataSize = totalElements * MemoryLayout<Float>.size
+    let inputSize = queryBytes.count
+    let outputSize = totalElements * MemoryLayout<Float>.size
 
-    let result1 = queryData.withUnsafeMutableBytes { ptr in
-      mfa_buffer_from_ptr(context, ptr.baseAddress, dataSize, &qBuffer)
+    let result1 = queryBytes.withUnsafeMutableBytes { ptr in
+      mfa_buffer_from_ptr(context, ptr.baseAddress, inputSize, &qBuffer)
     }
-    let result2 = keyData.withUnsafeMutableBytes { ptr in
-      mfa_buffer_from_ptr(context, ptr.baseAddress, dataSize, &kBuffer)
+    let result2 = keyBytes.withUnsafeMutableBytes { ptr in
+      mfa_buffer_from_ptr(context, ptr.baseAddress, inputSize, &kBuffer)
     }
-    let result3 = valueData.withUnsafeMutableBytes { ptr in
-      mfa_buffer_from_ptr(context, ptr.baseAddress, dataSize, &vBuffer)
+    let result3 = valueBytes.withUnsafeMutableBytes { ptr in
+      mfa_buffer_from_ptr(context, ptr.baseAddress, inputSize, &vBuffer)
     }
     let result4 = outputData.withUnsafeMutableBytes { ptr in
-      mfa_buffer_from_ptr(context, ptr.baseAddress, dataSize, &oBuffer)
+      mfa_buffer_from_ptr(context, ptr.baseAddress, outputSize, &oBuffer)
     }
 
     guard

--- a/Tests/MFAFFITests/MultiHeadFFITests.swift
+++ b/Tests/MFAFFITests/MultiHeadFFITests.swift
@@ -288,6 +288,16 @@ final class MultiHeadFFITests: XCTestCase {
   }
 
   private func testBugReproductionCases() throws {
+    // These reproduce historical NaN bugs at large sequence lengths
+    // (S=1024..8192) in low precision. GitHub's macOS runners expose an
+    // 'Apple Paravirtual device' without Apple7 family support, and the
+    // large-sequence low-precision kernels are not supported there —
+    // small-shape precision coverage above still runs. Same gate as the
+    // other stress suites.
+    guard TestEnvironment.supportsApple7 else {
+      print("  ⚠️ Skipping bug reproduction cases: requires Apple7+ GPU features")
+      return
+    }
     print("\n--- Bug Reproduction Test Cases ---")
 
     // Case 1: BF16/FP16 NaN bug reproduction with specific FLUX dimensions

--- a/Tests/MFAFFITests/SimplePrecisionTests.swift
+++ b/Tests/MFAFFITests/SimplePrecisionTests.swift
@@ -76,15 +76,15 @@ final class SimplePrecisionTests: XCTestCase {
       }
     }
 
-    // Call attention with FP32 precision (Swift enum value 0)
+    // Call attention with FP32 precision (C FFI enum: FP16=0, BF16=1, FP32=2)
     let result = mfa_attention_forward_nomask(
       context, q, k, v, out,
       batch, seqLen, seqLen, heads, headDim,
       1.0 / sqrtf(Float(headDim)), // softmax scale
       false, // not causal
-      0, // FP32 input precision (Swift enum)
-      0, // FP32 intermediate precision
-      0, // FP32 output precision
+      2, // FP32 input precision
+      2, // FP32 intermediate precision
+      2, // FP32 output precision
       false, false, false, false // no transpose
     )
 
@@ -150,6 +150,8 @@ final class SimplePrecisionTests: XCTestCase {
     var out: UnsafeMutableRawPointer?
 
     let bytes = elements * MemoryLayout<Float16>.size
+    // The kernel always stores O as FP32 regardless of the output label.
+    let outBytes = elements * MemoryLayout<Float>.size
 
     let qResult = mfa_create_buffer(context, bytes, &q)
     XCTAssertEqual(qResult, 0, "Failed to create Q buffer")
@@ -163,7 +165,7 @@ final class SimplePrecisionTests: XCTestCase {
     XCTAssertEqual(vResult, 0, "Failed to create V buffer")
     defer { mfa_destroy_buffer(v) }
 
-    let outResult = mfa_create_buffer(context, bytes, &out)
+    let outResult = mfa_create_buffer(context, outBytes, &out)
     XCTAssertEqual(outResult, 0, "Failed to create output buffer")
     defer { mfa_destroy_buffer(out) }
 
@@ -186,15 +188,15 @@ final class SimplePrecisionTests: XCTestCase {
       }
     }
 
-    // Call attention with FP16 precision (Swift enum value 1)
+    // Call attention with FP16 precision (C FFI enum: FP16=0, BF16=1, FP32=2)
     let result = mfa_attention_forward_nomask(
       context, q, k, v, out,
       batch, seqLen, seqLen, heads, headDim,
       1.0 / sqrtf(Float(headDim)), // softmax scale
       false, // not causal
-      1, // FP16 input precision (Swift enum)
-      1, // FP16 intermediate precision
-      1, // FP16 output precision
+      0, // FP16 input precision
+      0, // FP16 intermediate precision
+      0, // FP16 output precision
       false, false, false, false // no transpose
     )
 
@@ -202,7 +204,7 @@ final class SimplePrecisionTests: XCTestCase {
 
     // Check output for NaN
     if let outContents = mfa_buffer_contents(out) {
-      let outPointer = outContents.bindMemory(to: Float16.self, capacity: elements)
+      let outPointer = outContents.bindMemory(to: Float.self, capacity: elements)
       var nanCount = 0
       var nonZeroCount = 0
 
@@ -210,7 +212,7 @@ final class SimplePrecisionTests: XCTestCase {
         if outPointer[i].isNaN {
           nanCount += 1
         }
-        if abs(Float(outPointer[i])) > 1e-8 {
+        if abs(outPointer[i]) > 1e-8 {
           nonZeroCount += 1
         }
       }

--- a/examples/flux/flux_quick_benchmark.py
+++ b/examples/flux/flux_quick_benchmark.py
@@ -3,6 +3,7 @@
 Quick FLUX benchmark for Metal SDPA - Tests one resolution with minimal steps
 """
 
+import argparse
 import gc
 import os
 import sys
@@ -33,9 +34,6 @@ _prepend_dyld_library_path(
     ]
 )
 
-# Add the PyTorch custom op path to sys.path
-sys.path.insert(0, str(PROJECT_ROOT / "examples" / "pytorch-custom-op-ffi"))
-
 
 def _maybe_add_venv_site_packages() -> None:
     venv_root = Path(os.environ.get("VIRTUAL_ENV", PROJECT_ROOT / ".venv"))
@@ -48,6 +46,10 @@ def _maybe_add_venv_site_packages() -> None:
 
 
 _maybe_add_venv_site_packages()
+
+# Add the PyTorch custom op path ahead of site-packages so a freshly built
+# extension takes precedence over any stale installed copy
+sys.path.insert(0, str(PROJECT_ROOT / "examples" / "pytorch-custom-op-ffi"))
 
 # Try to import Metal SDPA extension
 try:
@@ -161,29 +163,89 @@ def restore_attention(original_sdpa):
         F.scaled_dot_product_attention = original_sdpa
 
 
-def run_quick_benchmark():
-    """Run a quick benchmark with 512x512 resolution and 2 steps"""
+def parse_args():
+    parser = argparse.ArgumentParser(description="Quick FLUX benchmark for Metal SDPA")
+    parser.add_argument(
+        "--model",
+        default="black-forest-labs/FLUX.1-schnell",
+        help="Hugging Face model id or local path for the Flux pipeline",
+    )
+    parser.add_argument(
+        "--steps", type=int, default=2, help="Number of inference steps"
+    )
+    parser.add_argument("--height", type=int, default=512, help="Image height")
+    parser.add_argument("--width", type=int, default=512, help="Image width")
+    parser.add_argument(
+        "--guidance-scale",
+        type=float,
+        default=None,
+        help="Guidance scale (default: 0.0 for schnell, 3.5 for dev-style models)",
+    )
+    parser.add_argument(
+        "--precision",
+        choices=["all", "vanilla", "bf16", "int8", "int4"],
+        default="all",
+        help="Which attention configuration(s) to benchmark",
+    )
+    parser.add_argument(
+        "--prompt", default="A simple test", help="Prompt used for generation"
+    )
+    parser.add_argument(
+        "--local-files-only",
+        action="store_true",
+        help="Load the model from the local Hugging Face cache without network access",
+    )
+    return parser.parse_args()
+
+
+def run_quick_benchmark(args):
+    """Run a quick benchmark at the requested resolution and step count"""
 
     if not DIFFUSERS_AVAILABLE:
         print("❌ Cannot run benchmark without diffusers")
         return
 
+    guidance_scale = args.guidance_scale
+    if guidance_scale is None:
+        guidance_scale = 0.0 if "schnell" in args.model.lower() else 3.5
+
     print("\n" + "=" * 60)
-    print("🚀 FLUX Quick Benchmark - 512x512, 2 steps")
+    print(f"🚀 FLUX Quick Benchmark - {args.width}x{args.height}, {args.steps} steps")
+    print(f"   Model: {args.model} (guidance_scale={guidance_scale})")
     print("=" * 60)
 
-    configs = [
-        ("PyTorch Vanilla", None),
+    all_configs = [
+        ("PyTorch Vanilla", "vanilla"),
         ("Metal UMFA BF16", "bf16"),
     ]
 
     if HAS_QUANTIZATION:
-        configs.extend(
+        all_configs.extend(
             [
                 ("Metal UMFA INT8", "int8"),
                 ("Metal UMFA INT4", "int4"),
             ]
         )
+
+    if args.precision == "all":
+        configs = all_configs
+    else:
+        configs = [(name, mode) for name, mode in all_configs if mode == args.precision]
+        if not configs:
+            print(f"❌ Precision '{args.precision}' not available in this build")
+            return
+
+    # Load the pipeline once and reuse it across configurations
+    print("\n📦 Loading pipeline (this can take a while for large models)...")
+    load_start = time.time()
+    pipe = FluxPipeline.from_pretrained(
+        args.model,
+        torch_dtype=torch.bfloat16,
+        local_files_only=args.local_files_only,
+    )
+    pipe = pipe.to("mps")
+    pipe.set_progress_bar_config(disable=True)
+    print(f"📦 Pipeline loaded in {time.time() - load_start:.1f}s")
 
     results = []
 
@@ -203,24 +265,16 @@ def run_quick_benchmark():
             original_sdpa = patch_attention(quantization)
 
         try:
-            # Load pipeline
-            print("  Loading pipeline...")
-            pipe = FluxPipeline.from_pretrained(
-                "black-forest-labs/FLUX.1-schnell", torch_dtype=torch.bfloat16
-            )
-            pipe = pipe.to("mps")
-
-            # Generate with minimal steps
             print("  Generating image...")
             start_time = time.time()
 
             with torch.inference_mode():
                 image = pipe(
-                    prompt="A simple test",
-                    num_inference_steps=2,  # Minimal steps
-                    height=512,
-                    width=512,
-                    guidance_scale=0.0,
+                    prompt=args.prompt,
+                    num_inference_steps=args.steps,
+                    height=args.height,
+                    width=args.width,
+                    guidance_scale=guidance_scale,
                     generator=torch.Generator().manual_seed(42),
                 ).images[0]
 
@@ -235,8 +289,6 @@ def run_quick_benchmark():
             print(f"  ✅ Time: {generation_time:.2f}s")
             results.append({"config": config_name, "time": generation_time})
 
-            # Clean up
-            del pipe
             if torch.backends.mps.is_available():
                 torch.mps.empty_cache()
             gc.collect()
@@ -268,4 +320,4 @@ def run_quick_benchmark():
 
 
 if __name__ == "__main__":
-    run_quick_benchmark()
+    run_quick_benchmark(parse_args())

--- a/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
+++ b/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
@@ -326,6 +326,31 @@ extern "C" {
         mfa_mask_scalar_t mask_scalar_type
     );
 
+    // Encode attention into a caller-provided MTLCommandBuffer without
+    // committing or waiting. Buffers are raw id<MTLBuffer> pointers, offsets
+    // in bytes. Optional masks are raw id<MTLBuffer> pointers plus tensor
+    // metadata and are expanded on the same command buffer before attention.
+    // The caller owns commit/completion — intended for encoding into PyTorch's
+    // MPS stream so no host sync is required.
+    mfa_error_t mfa_attention_encode_mtl(
+        mfa_context_t context,
+        void* command_buffer,
+        void* q_buffer, int64_t q_offset, const int64_t* q_strides,
+        void* k_buffer, int64_t k_offset, const int64_t* k_strides,
+        void* v_buffer, int64_t v_offset, const int64_t* v_strides,
+        void* out_buffer, int64_t out_offset,
+        void* mask_buffer, int64_t mask_offset,
+        const int64_t* mask_shape,
+        const int64_t* mask_strides,
+        uint32_t mask_ndim,
+        mfa_mask_type_t mask_type,
+        mfa_mask_scalar_t mask_scalar_type,
+        uint32_t batch_size, uint32_t seq_len_q, uint32_t seq_len_kv,
+        uint32_t num_heads, uint16_t head_dim, float softmax_scale,
+        bool causal,
+        const char* input_precision, const char* intermediate_precision
+    );
+
     mfa_error_t mfa_attention_forward_quantized(
         mfa_context_t context,
         mfa_buffer_t q, mfa_buffer_t k, mfa_buffer_t v, mfa_buffer_t out,
@@ -460,6 +485,7 @@ extern "C" {
         uint32_t batch_size, uint32_t seq_len_q, uint32_t seq_len_kv,
         uint32_t num_heads, uint16_t head_dim,
         float softmax_scale, bool causal,
+        int32_t input_precision, int32_t intermediate_precision,
         bool transpose_q, bool transpose_k,
         bool transpose_v, bool transpose_o);
 
@@ -473,6 +499,7 @@ extern "C" {
         uint32_t batch_size, uint32_t seq_len_q, uint32_t seq_len_kv,
         uint32_t num_heads, uint16_t head_dim,
         float softmax_scale, bool causal,
+        int32_t input_precision, int32_t intermediate_precision,
         bool transpose_q, bool transpose_k,
         bool transpose_v, bool transpose_o);
 
@@ -554,6 +581,22 @@ public:
         bool enable_gqa = false
     );
 
+    // Fused RoPE + SDPA (v1: forward/no-grad; gradient callers fall back to
+    // eager rotation + the normal dispatcher until the autograd backward
+    // with inverse rotation lands). Q/K/V are BHSD; rope_cos/rope_sin are
+    // pair-duplicated tables, [S, D] / [1, S, D] / [B, S, D], any float
+    // dtype (normalized to fp32 internally).
+    static torch::Tensor rope_scaled_dot_product_attention(
+        const torch::Tensor& query,
+        const torch::Tensor& key,
+        const torch::Tensor& value,
+        const torch::Tensor& rope_cos,
+        const torch::Tensor& rope_sin,
+        const c10::optional<torch::Tensor>& attn_mask,
+        bool is_causal,
+        c10::optional<double> scale
+    );
+
     // Unified quantized attention function - replaces all previous variants
     // This is the primary interface that supports all quantization features
     static torch::Tensor quantized_scaled_dot_product_attention_unified(
@@ -623,6 +666,8 @@ public:
         std::atomic<int64_t> quantized_autograd{0};
         std::atomic<int64_t> fp32_autograd{0};
         std::atomic<int64_t> fp32_direct{0};
+        std::atomic<int64_t> fp32_instream{0};
+        std::atomic<int64_t> rope_instream{0};
         std::atomic<int64_t> pytorch_fallback{0};
         std::atomic<int64_t> mask_all_true_skipped{0};
     };
@@ -641,6 +686,19 @@ private:
 
     // Helper methods
     static torch::Tensor call_swift_flash_attention(
+        const torch::Tensor& q,
+        const torch::Tensor& k,
+        const torch::Tensor& v,
+        const c10::optional<torch::Tensor>& attn_mask,
+        bool is_causal,
+        float softmax_scale
+    );
+
+    // Async fast path: encode into PyTorch's MPS stream (no syncs, no
+    // waits). Returns an undefined tensor when the call isn't eligible
+    // (non-MPS, non-4D, unsupported dtype/mask) or encoding fails, in
+    // which case the caller uses the legacy synchronous path.
+    static torch::Tensor try_instream_flash_attention(
         const torch::Tensor& q,
         const torch::Tensor& k,
         const torch::Tensor& v,

--- a/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
+++ b/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
@@ -7,6 +7,7 @@
 #include <c10/core/ScalarType.h>
 #include <mutex>
 #include <optional>
+#include <map>
 
 namespace metal_sdpa {
 
@@ -599,17 +600,35 @@ public:
 
     static mfa_context_t get_swift_context() { return swift_context_; }
 
+    // ---- Quantization mode constants (exposed to Python) ----
+    static constexpr int32_t QUANT_NONE = 0;
+    static constexpr int32_t QUANT_INT8 = 3;
+    static constexpr int32_t QUANT_INT4 = 4;
+    static constexpr int32_t QUANT_TENSOR_WISE = 0;
+    static constexpr int32_t QUANT_BLOCK_WISE = 2;
+
     // Global quantization mode for dispatcher-level SDPA routing.
-    // When active, scaled_dot_product_attention routes through
-    // MetalQuantizedFlashAttentionFn instead of the FP32 path.
-    // Set by SimpleTuner's int8/int4 profiles via set_quantization_mode().
     static std::atomic<int32_t>& quant_precision() {
-        static std::atomic<int32_t> v{0}; // 0=disabled, 3=INT8, 4=INT4
+        static std::atomic<int32_t> v{0};
         return v;
     }
     static std::atomic<int32_t>& quant_block_mode() {
-        static std::atomic<int32_t> v{0}; // 0=tensorWise, 2=blockwise
+        static std::atomic<int32_t> v{0};
         return v;
+    }
+
+    // ---- Dispatch counters (observable from Python) ----
+    struct DispatchStats {
+        std::atomic<int64_t> total{0};
+        std::atomic<int64_t> quantized_autograd{0};
+        std::atomic<int64_t> fp32_autograd{0};
+        std::atomic<int64_t> fp32_direct{0};
+        std::atomic<int64_t> pytorch_fallback{0};
+        std::atomic<int64_t> mask_all_true_skipped{0};
+    };
+    static DispatchStats& dispatch_stats() {
+        static DispatchStats s;
+        return s;
     }
 
 private:
@@ -741,10 +760,11 @@ namespace metal_sdpa {
     std::tuple<int, int, int> get_version();
 
     // Quantization mode control for dispatcher-level SDPA routing.
-    // precision: 0=disabled, 3=INT8, 4=INT4
-    // block_mode: 0=tensorWise, 2=blockwise
+    // Use QUANT_* constants as precision values.
     void set_quantization_mode(int64_t precision, int64_t block_mode);
     void clear_quantization_mode();
+    std::map<std::string, int64_t> get_dispatch_stats();
+    void reset_dispatch_stats();
 }
 
 // =============================================================================

--- a/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
+++ b/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
@@ -478,16 +478,16 @@ extern "C" {
 
     // Multi-head quantized attention with autograd support.
     // Forward: runtime-quantizes Q/K/V to INT8, runs quantized flash
-    // attention, writes output + LSE.
+    // attention, writes output + LSE. Optional mask (float32 additive
+    // [B,H,S_q,S_kv] or nil).
     int32_t mfa_quantized_forward_with_lse(
         mfa_context_t context,
         mfa_buffer_t q, mfa_buffer_t k, mfa_buffer_t v,
-        mfa_buffer_t out, mfa_buffer_t lse,
+        mfa_buffer_t out, mfa_buffer_t lse, mfa_buffer_t mask,
         uint32_t batch_size, uint32_t seq_len_q, uint32_t seq_len_kv,
         uint32_t num_heads, uint16_t head_dim,
         float softmax_scale, bool causal,
-        int32_t target_precision, // 3=INT8, 4=INT4
-        int32_t quant_mode);       // 0=tensorWise, 2=blockwise
+        int32_t target_precision, int32_t quant_mode);
 
     // Backward: re-quantizes Q/K/V, runs quantized flash backward.
     int32_t mfa_quantized_backward(
@@ -495,11 +495,11 @@ extern "C" {
         mfa_buffer_t q, mfa_buffer_t k, mfa_buffer_t v,
         mfa_buffer_t out, mfa_buffer_t grad_out, mfa_buffer_t lse,
         mfa_buffer_t grad_q, mfa_buffer_t grad_k, mfa_buffer_t grad_v,
+        mfa_buffer_t mask,
         uint32_t batch_size, uint32_t seq_len_q, uint32_t seq_len_kv,
         uint32_t num_heads, uint16_t head_dim,
         float softmax_scale, bool causal,
-        int32_t target_precision,
-        int32_t quant_mode);
+        int32_t target_precision, int32_t quant_mode);
 
     // =============================================================================
     // Multi-Latent Attention (MLA) Support

--- a/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
+++ b/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
@@ -638,6 +638,7 @@ public:
     );
 
     friend class MetalFlashAttentionFn;
+    friend class MetalRopeFlashAttentionFn;
     friend class MetalQuantizedFlashAttentionFn;
     friend void hadamard_rotate_inplace(torch::Tensor, int64_t);
 

--- a/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
+++ b/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
@@ -599,6 +599,19 @@ public:
 
     static mfa_context_t get_swift_context() { return swift_context_; }
 
+    // Global quantization mode for dispatcher-level SDPA routing.
+    // When active, scaled_dot_product_attention routes through
+    // MetalQuantizedFlashAttentionFn instead of the FP32 path.
+    // Set by SimpleTuner's int8/int4 profiles via set_quantization_mode().
+    static std::atomic<int32_t>& quant_precision() {
+        static std::atomic<int32_t> v{0}; // 0=disabled, 3=INT8, 4=INT4
+        return v;
+    }
+    static std::atomic<int32_t>& quant_block_mode() {
+        static std::atomic<int32_t> v{0}; // 0=tensorWise, 2=blockwise
+        return v;
+    }
+
 private:
     static mfa_context_t swift_context_;
     static bool is_initialized_;
@@ -726,6 +739,12 @@ namespace metal_sdpa {
     // Utility functions for Python binding
     bool is_metal_available();
     std::tuple<int, int, int> get_version();
+
+    // Quantization mode control for dispatcher-level SDPA routing.
+    // precision: 0=disabled, 3=INT8, 4=INT4
+    // block_mode: 0=tensorWise, 2=blockwise
+    void set_quantization_mode(int64_t precision, int64_t block_mode);
+    void clear_quantization_mode();
 }
 
 // =============================================================================

--- a/examples/pytorch-custom-op-ffi/include/mps_utils.h
+++ b/examples/pytorch-custom-op-ffi/include/mps_utils.h
@@ -10,5 +10,50 @@ bool is_mps_tensor(const at::Tensor& tensor);
 // Returns opaque pointer to id<MTLBuffer> (or nullptr on failure)
 void* get_mtl_buffer_handle(const at::Tensor& tensor);
 
+// Encode UMFA attention into PyTorch's current MPS-stream command buffer and
+// commit (without waiting). Q/K/V/output must be contiguous MPS tensors in
+// BHSD layout with matching dtypes. Optional masks must be MPS tensors with
+// <=4 dims; they are expanded on the same command buffer before attention.
+// Ordering against surrounding torch ops is automatic because the kernels
+// ride the same stream — no host synchronization happens anywhere.
+// Returns 0 on success, an mfa_error_t code otherwise.
+// Encode one RoPE rotation (interleaved-pair, fp32 math, pair-duplicated
+// fp32 tables) into the current MPS-stream command buffer WITHOUT
+// committing. src may be a strided BHSD view (last dim contiguous); dst is
+// dense BHSD, same dtype. negate_sin selects the inverse rotation (dQ/dK
+// backward). The caller encodes attention afterwards and commits once.
+int encode_rope_rotate_on_torch_stream(
+    void* mfa_context,
+    const at::Tensor& src,
+    const at::Tensor& dst,
+    const at::Tensor& cos_table,
+    const at::Tensor& sin_table,
+    int64_t table_batch_stride,
+    bool negate_sin,
+    uint32_t batch_size,
+    uint32_t num_heads,
+    uint32_t seq_len,
+    uint32_t head_dim,
+    const char* precision);
+
+int encode_attention_on_torch_stream(
+    void* mfa_context,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& out,
+    const at::Tensor* mask,
+    int mask_type,
+    int mask_scalar_type,
+    uint32_t batch_size,
+    uint32_t seq_len_q,
+    uint32_t seq_len_kv,
+    uint32_t num_heads,
+    uint16_t head_dim,
+    float softmax_scale,
+    bool is_causal,
+    const char* input_precision,
+    const char* intermediate_precision);
+
 } // namespace mps_utils
 } // namespace metal_sdpa

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -27,7 +27,8 @@ torch::Tensor metal_quantized_flash_attention_autograd(
     bool is_causal,
     double scale,
     int64_t target_precision,
-    int64_t quant_mode);
+    int64_t quant_mode,
+    c10::optional<torch::Tensor> attn_mask);
 
 torch::Tensor metal_flash_attention_autograd(
     const torch::Tensor& query,
@@ -1374,18 +1375,20 @@ torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
     }
 
     // ---- Route to quantized autograd when INT8/INT4 mode is active ----
-    if (quant_precision().load() != 0 && !has_real_mask) {
+    // Now handles arbitrary masks (bool, additive, batched).
+    if (quant_precision().load() != 0) {
         stats.quantized_autograd.fetch_add(1, std::memory_order_relaxed);
         return metal_quantized_flash_attention_autograd(
             query, key, value, is_causal, sm_scale,
             static_cast<int64_t>(quant_precision().load()),
-            static_cast<int64_t>(quant_block_mode().load()));
+            static_cast<int64_t>(quant_block_mode().load()),
+            has_real_mask ? attn_mask : c10::optional<torch::Tensor>());
     }
 
     // ---- Route to FP32 autograd when inputs require grad ----
     bool needs_autograd = query.requires_grad() || key.requires_grad() ||
                           value.requires_grad();
-    if (needs_autograd && !has_real_mask) {
+    if (needs_autograd) {
         stats.fp32_autograd.fetch_add(1, std::memory_order_relaxed);
         return metal_flash_attention_autograd(
             query, key, value, is_causal, sm_scale);
@@ -2420,7 +2423,8 @@ public:
       torch::autograd::AutogradContext *ctx,
       torch::Tensor query, torch::Tensor key, torch::Tensor value,
       bool is_causal, double scale,
-      int64_t target_precision, int64_t quant_mode) {
+      int64_t target_precision, int64_t quant_mode,
+      c10::optional<torch::Tensor> attn_mask = c10::nullopt) {
 
     MetalSDPABackend::ensure_initialized();
     auto mfa_ctx = MetalSDPABackend::get_swift_context();
@@ -2464,9 +2468,32 @@ public:
     auto out_b = bind(output);
     auto lse_b = bind(lse);
 
+    // Preprocess mask: convert to float32 additive [B, H, S_q, S_kv].
+    // Bool: True→0.0 (attend), False→-inf (mask out).
+    // Float: pass through as-is.
+    torch::Tensor mask_tensor;
+    mfa_buffer_t mask_b = nullptr;
+    if (attn_mask.has_value() && attn_mask.value().defined()) {
+        auto m = attn_mask.value();
+        if (m.scalar_type() == torch::kBool) {
+            m = m.to(torch::kFloat32);
+            m.masked_fill_(m == 0.0f, -std::numeric_limits<float>::infinity());
+        } else {
+            m = m.to(torch::kFloat32);
+        }
+        // Expand to [B, H, S_q, S_kv]
+        while (m.dim() < 4) m = m.unsqueeze(0);
+        m = m.expand({batch, heads, seq_q, seq_kv}).contiguous();
+        mask_tensor = m;
+        if (query.device().type() == at::kMPS) {
+            torch::mps::synchronize();
+        }
+        mask_b = bind(mask_tensor);
+    }
+
     auto result = mfa_quantized_forward_with_lse(
         mfa_ctx,
-        q_b, k_b, v_b, out_b, lse_b,
+        q_b, k_b, v_b, out_b, lse_b, mask_b,
         batch, seq_q, seq_kv, heads, dim,
         sm_scale, is_causal,
         static_cast<int32_t>(target_precision),
@@ -2477,6 +2504,7 @@ public:
     mfa_destroy_buffer(v_b);
     mfa_destroy_buffer(out_b);
     mfa_destroy_buffer(lse_b);
+    if (mask_b) mfa_destroy_buffer(mask_b);
 
     if (result != 0) {
       throw std::runtime_error(
@@ -2490,6 +2518,9 @@ public:
     ctx->saved_data["is_causal"] = is_causal;
     ctx->saved_data["target_precision"] = target_precision;
     ctx->saved_data["quant_mode"] = quant_mode;
+    if (mask_tensor.defined()) {
+        ctx->saved_data["mask"] = mask_tensor;
+    }
 
     return output;
   }
@@ -2508,6 +2539,10 @@ public:
     bool is_causal = ctx->saved_data["is_causal"].toBool();
     int64_t target_precision = ctx->saved_data["target_precision"].toInt();
     int64_t quant_mode = ctx->saved_data["quant_mode"].toInt();
+    torch::Tensor mask_tensor;
+    if (ctx->saved_data.count("mask") && ctx->saved_data["mask"].isTensor()) {
+        mask_tensor = ctx->saved_data["mask"].toTensor();
+    }
 
     auto d_output = grad_outputs[0].to(torch::kFloat32).contiguous();
 
@@ -2547,11 +2582,19 @@ public:
     auto dk_b = bind(d_key);
     auto dv_b = bind(d_value);
 
+    mfa_buffer_t mask_b = nullptr;
+    if (mask_tensor.defined()) {
+        if (query.device().type() == at::kMPS) {
+            torch::mps::synchronize();
+        }
+        mask_b = bind(mask_tensor);
+    }
+
     auto result = mfa_quantized_backward(
         mfa_ctx,
         q_b, k_b, v_b,
         out_b, dout_b, lse_b,
-        dq_b, dk_b, dv_b,
+        dq_b, dk_b, dv_b, mask_b,
         batch, seq_q, seq_kv, heads, dim,
         sm_scale, is_causal,
         static_cast<int32_t>(target_precision),
@@ -2566,6 +2609,7 @@ public:
     mfa_destroy_buffer(dq_b);
     mfa_destroy_buffer(dk_b);
     mfa_destroy_buffer(dv_b);
+    if (mask_b) mfa_destroy_buffer(mask_b);
 
     if (result != 0) {
       throw std::runtime_error(
@@ -2575,7 +2619,8 @@ public:
 
     return {d_query, d_key, d_value,
             torch::Tensor(), torch::Tensor(),
-            torch::Tensor(), torch::Tensor()};
+            torch::Tensor(), torch::Tensor(),
+            torch::Tensor()};
   }
 };
 
@@ -2586,10 +2631,11 @@ torch::Tensor metal_quantized_flash_attention_autograd(
     bool is_causal,
     double scale,
     int64_t target_precision,
-    int64_t quant_mode) {
+    int64_t quant_mode,
+    c10::optional<torch::Tensor> attn_mask = c10::nullopt) {
   return MetalQuantizedFlashAttentionFn::apply(
       query, key, value, is_causal, scale,
-      target_precision, quant_mode);
+      target_precision, quant_mode, attn_mask);
 }
 
 // Hadamard rotation helper for Python binding

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -18,6 +18,23 @@
 
 namespace metal_sdpa {
 
+// Forward declarations — defined later in this file.
+torch::Tensor metal_quantized_flash_attention_autograd(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    bool is_causal,
+    double scale,
+    int64_t target_precision,
+    int64_t quant_mode);
+
+torch::Tensor metal_flash_attention_autograd(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    bool is_causal,
+    double scale);
+
 namespace {
 
 bool cpu_fallback_allowed() {
@@ -1333,6 +1350,28 @@ torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
         // Ensure backend is initialized
         ensure_initialized();
 
+    double sm_scale = scale.value_or(0.0);
+    bool has_mask = attn_mask.has_value() && attn_mask.value().defined();
+
+    // Route to quantized autograd when INT8/INT4 mode is active.
+    if (quant_precision().load() != 0 && !has_mask) {
+        return metal_quantized_flash_attention_autograd(
+            query, key, value, is_causal, sm_scale,
+            static_cast<int64_t>(quant_precision().load()),
+            static_cast<int64_t>(quant_block_mode().load()));
+    }
+
+    // Route to FP32 autograd when inputs require grad and no mask.
+    // This ensures gradients flow through F.scaled_dot_product_attention
+    // at the dispatcher level (otherwise PyTorch warns about missing
+    // autograd kernels).
+    bool needs_autograd = query.requires_grad() || key.requires_grad() ||
+                          value.requires_grad();
+    if (needs_autograd && !has_mask) {
+        return metal_flash_attention_autograd(
+            query, key, value, is_causal, sm_scale);
+    }
+
     // Validate inputs
     if (dropout_p > 0.0) {
         std::cout << "Warning: Dropout not supported in Metal Flash Attention, ignoring dropout_p" << std::endl;
@@ -2551,9 +2590,22 @@ void hadamard_rotate_inplace(torch::Tensor tensor, int64_t block_size) {
     }
 }
 
+void set_quantization_mode(int64_t precision, int64_t block_mode) {
+    MetalSDPABackend::quant_precision().store(static_cast<int32_t>(precision));
+    MetalSDPABackend::quant_block_mode().store(static_cast<int32_t>(block_mode));
+}
+
+void clear_quantization_mode() {
+    MetalSDPABackend::quant_precision().store(0);
+}
+
 } // namespace metal_sdpa
 
-// Register the custom SDPA implementation for PrivateUse1 backend
-TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
+// Register the custom SDPA implementation for MPS backend.
+// PyTorch 2.x uses the "MPS" dispatch key (not "PrivateUse1") for
+// torch.device("mps") tensors. This overrides PyTorch's native MPS SDPA
+// with UMFA's flash-attention implementation for all F.scaled_dot_product_attention
+// calls on MPS tensors.
+TORCH_LIBRARY_IMPL(aten, MPS, m) {
     m.impl("scaled_dot_product_attention", &metal_sdpa::MetalSDPABackend::scaled_dot_product_attention);
 }

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -1076,6 +1076,14 @@ torch::Tensor MetalSDPABackend::call_swift_flash_attention_impl(
     promote_to_fp32(k_tensor);
     promote_to_fp32(v_tensor);
 
+    // Synchronize after FP16→FP32 promotion — the .to(kFloat32) conversion
+    // is enqueued on PyTorch's MPS command queue, but UMFA's kernel reads
+    // the buffer via a separate Metal command queue. Without this sync, the
+    // first dispatch reads stale/uninitialised memory (producing zeros).
+    if (promoted_precision && use_mps_buffers) {
+        torch::mps::synchronize();
+    }
+
     auto output = torch::empty_like(q_tensor);
     auto describe_shape = [](const torch::Tensor& t) {
         std::string s = "[";

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -1419,9 +1419,6 @@ torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
             v.scalar_type() != q.scalar_type()) {
             return true;
         }
-        if (q.size(1) < 4 || q.size(2) < 64) {
-            return true;
-        }
         return false;
     };
 
@@ -1503,6 +1500,15 @@ torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
     // Call Swift Flash Attention (using processed tensors from call_swift_flash_attention)
     stats.fp32_direct.fetch_add(1, std::memory_order_relaxed);
     auto result = call_swift_flash_attention(q, k, v, attn_mask, is_causal, softmax_scale);
+
+    // Runtime NaN safety net — certain head_dim values trigger a kernel bug
+    // (likely in block dimension padding). Fall back to PyTorch native.
+    if (torch::isnan(result).any().item<bool>()) {
+        stats.fp32_direct.fetch_sub(1, std::memory_order_relaxed);
+        stats.pytorch_fallback.fetch_add(1, std::memory_order_relaxed);
+        return at::native::scaled_dot_product_attention(
+            query, key, value, attn_mask, dropout_p, is_causal, scale, enable_gqa);
+    }
 
     // Convert result back to original layout if input was FLUX
     // Note: The layout conversion is now handled within call_swift_flash_attention

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -37,6 +37,16 @@ torch::Tensor metal_flash_attention_autograd(
     bool is_causal,
     double scale);
 
+torch::Tensor metal_rope_flash_attention_autograd(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& cos_t,
+    const torch::Tensor& sin_t,
+    int64_t table_batch_stride,
+    bool is_causal,
+    double scale);
+
 namespace {
 
 bool cpu_fallback_allowed() {
@@ -1480,15 +1490,8 @@ torch::Tensor MetalSDPABackend::rope_scaled_dot_product_attention(
             q_rot, k_rot, value, attn_mask, 0.0, is_causal, scale, true);
     };
 
-    // v1 fused path is forward-only: attention backward returns gradients
-    // w.r.t. rotated Q/K, and the model needs pre-RoPE gradients (inverse
-    // rotation on dQ/dK). Until that autograd lands, gradient callers use
-    // the eager rotation, which flows through the existing autograd path.
     const bool needs_grad = at::GradMode::is_enabled() &&
         (query.requires_grad() || key.requires_grad() || value.requires_grad());
-    if (needs_grad) {
-        return eager();
-    }
     if (!swift_context_ ||
         !query.device().is_mps() || !key.device().is_mps() || !value.device().is_mps()) {
         return eager();
@@ -1554,6 +1557,25 @@ torch::Tensor MetalSDPABackend::rope_scaled_dot_product_attention(
     }
     // Table rows are indexed as s * D, so rows beyond Sq are simply unused;
     // a 2D table with more rows than Sq is fine, a batched one too.
+
+    // Gradient callers: fused forward + autograd backward with the inverse
+    // rotation on dQ/dK (RoPE is orthonormal, so the backward transform is
+    // the same pairwise rotation with sin negated). Causal is supported —
+    // both bitmask and elementwise transposed causal codegen verified exact.
+    // Masks and GQA still take the eager path: the attention-backward
+    // primitive does not accept masks, and GQA head expansion would need a
+    // grouped reduction in backward.
+    if (needs_grad) {
+        if ((attn_mask.has_value() && attn_mask.value().defined()) ||
+            Hq != Hkv) {
+            return eager();
+        }
+        auto result = metal_rope_flash_attention_autograd(
+            query, key, value, cos_t, sin_t, table_batch_stride, is_causal,
+            scale.has_value() ? scale.value() : 0.0);
+        dispatch_stats().rope_instream.fetch_add(1, std::memory_order_relaxed);
+        return result;
+    }
 
     const char* precision = dt == torch::kFloat16 ? "fp16"
         : dt == torch::kBFloat16                  ? "bf16"
@@ -2814,6 +2836,269 @@ torch::Tensor metal_flash_attention_autograd(
     bool is_causal,
     double scale) {
   return MetalFlashAttentionFn::apply(query, key, value, is_causal, scale);
+}
+
+// =============================================================================
+// Fused RoPE + Flash Attention with Autograd
+// =============================================================================
+//
+// forward:  q_rot = R(q); k_rot = R(k); out, lse = attention(q_rot, k_rot, v)
+// backward: d_q_rot, d_k_rot, d_v = attention_backward(...)
+//           d_q = R^-1(d_q_rot); d_k = R^-1(d_k_rot)
+// RoPE is orthonormal, so the inverse rotation is the same pairwise rotation
+// with sin negated (the rotation kernel's negate_sin parameter). Rotations
+// are encoded on the torch MPS stream; the attention primitives synchronize
+// before reading, matching the existing autograd path's ordering model.
+class MetalRopeFlashAttentionFn
+    : public torch::autograd::Function<MetalRopeFlashAttentionFn> {
+public:
+  static torch::Tensor forward(
+      torch::autograd::AutogradContext *ctx,
+      torch::Tensor query, torch::Tensor key, torch::Tensor value,
+      torch::Tensor cos_t, torch::Tensor sin_t,
+      int64_t table_batch_stride, bool is_causal, double scale) {
+
+    MetalSDPABackend::ensure_initialized();
+    auto mfa_ctx = MetalSDPABackend::get_swift_context();
+    if (!mfa_ctx) {
+      throw std::runtime_error("Metal SDPA backend not initialized");
+    }
+
+    auto orig_dtype = query.scalar_type();
+    auto input_precision = MetalSDPABackend::torch_dtype_to_mfa_dtype(orig_dtype);
+    const char *precision = orig_dtype == torch::kFloat16 ? "fp16"
+        : orig_dtype == torch::kBFloat16                  ? "bf16"
+                                                          : "fp32";
+
+    auto q_sizes = query.sizes();
+    uint32_t batch = static_cast<uint32_t>(q_sizes[0]);
+    uint32_t heads = static_cast<uint32_t>(q_sizes[1]);
+    uint32_t seq_q = static_cast<uint32_t>(q_sizes[2]);
+    uint32_t seq_kv = static_cast<uint32_t>(key.size(2));
+    uint16_t dim = static_cast<uint16_t>(q_sizes[3]);
+
+    float sm_scale = static_cast<float>(scale);
+    if (scale == 0.0) {
+      sm_scale = 1.0f / std::sqrt(static_cast<float>(dim));
+    }
+
+    // Rotate Q/K on the torch stream into dense scratch. The rotation kernel
+    // reads strided views with a contiguous last dim directly.
+    auto rope_src_ok = [](const torch::Tensor &t) {
+      if (t.is_contiguous()) {
+        return true;
+      }
+      auto st = t.strides();
+      return st[3] == 1 && st[0] >= 0 && st[1] >= 0 && st[2] >= 0;
+    };
+    auto q_src = rope_src_ok(query) ? query : query.contiguous();
+    auto k_src = rope_src_ok(key) ? key : key.contiguous();
+    auto q_rot = torch::empty(query.sizes(), query.options());
+    auto k_rot = torch::empty(key.sizes(), key.options());
+
+    int rc = mps_utils::encode_rope_rotate_on_torch_stream(
+        mfa_ctx, q_src, q_rot, cos_t, sin_t, table_batch_stride,
+        /*negate_sin=*/false, batch, heads, seq_q, dim, precision);
+    if (rc == 0) {
+      rc = mps_utils::encode_rope_rotate_on_torch_stream(
+          mfa_ctx, k_src, k_rot, cos_t, sin_t, table_batch_stride,
+          /*negate_sin=*/false, batch, heads, seq_kv, dim, precision);
+    }
+    if (rc != 0) {
+      throw std::runtime_error(
+          "RoPE rotation encode failed with code " + std::to_string(rc));
+    }
+
+    value = value.contiguous();
+    // Drain the torch stream so the rotations (and any producer ops) are
+    // visible to the attention primitive running on UMFA's own queue.
+    if (query.device().type() == at::kMPS) {
+      torch::mps::synchronize();
+    }
+
+    auto output_dtype = orig_dtype == torch::kFloat32 ? orig_dtype : torch::kFloat32;
+    auto output = torch::empty(query.sizes(), query.options().dtype(output_dtype));
+    auto lse = torch::empty(
+        {batch * heads * seq_q}, torch::kFloat32).to(query.device());
+
+    auto bind = [&](torch::Tensor &t) -> mfa_buffer_t {
+      mfa_buffer_t h = nullptr;
+      auto mtl = mps_utils::get_mtl_buffer_handle(t);
+      mfa_buffer_from_mtl_buffer(mfa_ctx, mtl, t.nbytes(), &h);
+      return h;
+    };
+    auto q_b = bind(q_rot);
+    auto k_b = bind(k_rot);
+    auto v_b = bind(value);
+    auto out_b = bind(output);
+    auto lse_b = bind(lse);
+
+    auto result = mfa_attention_forward_with_lse(
+        mfa_ctx,
+        q_b, k_b, v_b, out_b, lse_b,
+        batch, seq_q, seq_kv, heads, dim,
+        sm_scale, is_causal,
+        input_precision, input_precision,
+        false, false, false, false);
+
+    mfa_destroy_buffer(q_b);
+    mfa_destroy_buffer(k_b);
+    mfa_destroy_buffer(v_b);
+    mfa_destroy_buffer(out_b);
+    mfa_destroy_buffer(lse_b);
+
+    if (result != 0) {
+      throw std::runtime_error(
+          "RoPE MetalFlashAttention forward failed with code " +
+          std::to_string(result));
+    }
+
+    auto returned_output = output;
+    if (output.scalar_type() != orig_dtype) {
+      returned_output = output.to(orig_dtype);
+    }
+
+    ctx->save_for_backward({q_rot, k_rot, value, output, cos_t, sin_t});
+    ctx->saved_data["lse"] = lse;
+    ctx->saved_data["scale"] = sm_scale;
+    ctx->saved_data["table_batch_stride"] = table_batch_stride;
+    ctx->saved_data["is_causal"] = is_causal;
+    ctx->saved_data["orig_dtype"] = static_cast<int64_t>(orig_dtype);
+    ctx->saved_data["input_precision"] = static_cast<int64_t>(input_precision);
+
+    return returned_output;
+  }
+
+  static torch::autograd::tensor_list backward(
+      torch::autograd::AutogradContext *ctx,
+      torch::autograd::tensor_list grad_outputs) {
+
+    MetalSDPABackend::ensure_initialized();
+    auto mfa_ctx = MetalSDPABackend::get_swift_context();
+    auto saved = ctx->get_saved_variables();
+    auto q_rot = saved[0];
+    auto k_rot = saved[1];
+    auto value = saved[2];
+    auto output_fp32 = saved[3];
+    auto cos_t = saved[4];
+    auto sin_t = saved[5];
+    auto lse = ctx->saved_data["lse"].toTensor();
+    float sm_scale = static_cast<float>(ctx->saved_data["scale"].toDouble());
+    int64_t table_batch_stride = ctx->saved_data["table_batch_stride"].toInt();
+    bool is_causal = ctx->saved_data["is_causal"].toBool();
+    auto orig_dtype = static_cast<torch::ScalarType>(
+        ctx->saved_data["orig_dtype"].toInt());
+    auto input_precision = static_cast<mfa_precision_t>(
+        ctx->saved_data["input_precision"].toInt());
+
+    auto d_output = grad_outputs[0];
+    auto d_output_dtype = orig_dtype == torch::kFloat32 ? torch::kFloat32 : orig_dtype;
+    if (d_output.scalar_type() != d_output_dtype) {
+      d_output = d_output.to(d_output_dtype);
+    }
+    d_output = d_output.contiguous();
+    if (q_rot.device().type() == at::kMPS) {
+      torch::mps::synchronize();
+    }
+
+    auto q_sizes = q_rot.sizes();
+    uint32_t batch = static_cast<uint32_t>(q_sizes[0]);
+    uint32_t heads = static_cast<uint32_t>(q_sizes[1]);
+    uint32_t seq_q = static_cast<uint32_t>(q_sizes[2]);
+    uint32_t seq_kv = static_cast<uint32_t>(k_rot.size(2));
+    uint16_t dim = static_cast<uint16_t>(q_sizes[3]);
+
+    auto fp32_options = q_rot.options().dtype(torch::kFloat32);
+    auto d_q_rot = torch::zeros(q_rot.sizes(), fp32_options);
+    auto d_k_rot = torch::zeros(k_rot.sizes(), fp32_options);
+    auto d_value = torch::zeros(value.sizes(), fp32_options);
+    auto d_buffer = torch::zeros(
+        {batch * heads * seq_q}, torch::kFloat32).to(q_rot.device());
+
+    auto bind = [&](torch::Tensor &t) -> mfa_buffer_t {
+      mfa_buffer_t h = nullptr;
+      auto mtl = mps_utils::get_mtl_buffer_handle(t);
+      mfa_buffer_from_mtl_buffer(mfa_ctx, mtl, t.nbytes(), &h);
+      return h;
+    };
+    auto dout_b = bind(d_output);
+    auto q_b = bind(q_rot);
+    auto k_b = bind(k_rot);
+    auto v_b = bind(value);
+    auto out_b = bind(output_fp32);
+    auto lse_b = bind(lse);
+    auto dq_b = bind(d_q_rot);
+    auto dk_b = bind(d_k_rot);
+    auto dv_b = bind(d_value);
+    auto d_b = bind(d_buffer);
+
+    auto result = mfa_attention_backward(
+        mfa_ctx,
+        dout_b, q_b, k_b, v_b, out_b, lse_b,
+        dq_b, dk_b, dv_b, d_b,
+        batch, seq_q, seq_kv, heads, dim,
+        sm_scale, is_causal,
+        input_precision, input_precision,
+        false, false, false, false);
+
+    mfa_destroy_buffer(dout_b);
+    mfa_destroy_buffer(q_b);
+    mfa_destroy_buffer(k_b);
+    mfa_destroy_buffer(v_b);
+    mfa_destroy_buffer(out_b);
+    mfa_destroy_buffer(lse_b);
+    mfa_destroy_buffer(dq_b);
+    mfa_destroy_buffer(dk_b);
+    mfa_destroy_buffer(dv_b);
+    mfa_destroy_buffer(d_b);
+
+    if (result != 0) {
+      throw std::runtime_error(
+          "RoPE MetalFlashAttention backward failed with code " +
+          std::to_string(result));
+    }
+
+    // Inverse rotation on dQ/dK (negate_sin) — gradients w.r.t. pre-RoPE
+    // Q/K. Encoded on the torch stream; the attention backward has already
+    // completed (its command buffer is waited on inside the FFI call).
+    auto d_query = torch::empty(d_q_rot.sizes(), fp32_options);
+    auto d_key = torch::empty(d_k_rot.sizes(), fp32_options);
+    int rc = mps_utils::encode_rope_rotate_on_torch_stream(
+        mfa_ctx, d_q_rot, d_query, cos_t, sin_t, table_batch_stride,
+        /*negate_sin=*/true, batch, heads, seq_q, dim, "fp32");
+    if (rc == 0) {
+      rc = mps_utils::encode_rope_rotate_on_torch_stream(
+          mfa_ctx, d_k_rot, d_key, cos_t, sin_t, table_batch_stride,
+          /*negate_sin=*/true, batch, heads, seq_kv, dim, "fp32");
+    }
+    if (rc != 0) {
+      throw std::runtime_error(
+          "RoPE inverse rotation encode failed with code " + std::to_string(rc));
+    }
+
+    if (orig_dtype != torch::kFloat32) {
+      d_query = d_query.to(orig_dtype);
+      d_key = d_key.to(orig_dtype);
+      d_value = d_value.to(orig_dtype);
+    }
+
+    return {d_query, d_key, d_value,
+            torch::Tensor(), torch::Tensor(), torch::Tensor(),
+            torch::Tensor(), torch::Tensor()};
+  }
+};
+
+torch::Tensor metal_rope_flash_attention_autograd(
+    const torch::Tensor &query,
+    const torch::Tensor &key,
+    const torch::Tensor &value,
+    const torch::Tensor &cos_t,
+    const torch::Tensor &sin_t,
+    int64_t table_batch_stride,
+    bool is_causal,
+    double scale) {
+  return MetalRopeFlashAttentionFn::apply(
+      query, key, value, cos_t, sin_t, table_batch_stride, is_causal, scale);
 }
 
 // =============================================================================

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -188,10 +188,6 @@ torch::Tensor convert_flux_to_metal_layout(const torch::Tensor& flux_tensor) {
 
     auto metal_tensor = flux_tensor.contiguous();
 
-    printf("🔄 FLUX->Metal (passthrough BHSD): %s dtype=%s\n",
-           ("[" + std::to_string(flux_tensor.size(0)) + "," + std::to_string(flux_tensor.size(1)) + "," + std::to_string(flux_tensor.size(2)) + "," + std::to_string(flux_tensor.size(3)) + "]").c_str(),
-           scalar_type_to_string(flux_tensor.scalar_type()).c_str());
-
     return metal_tensor;
 }
 
@@ -203,10 +199,6 @@ torch::Tensor convert_metal_to_flux_layout(const torch::Tensor& metal_tensor) {
     }
 
     auto flux_tensor = metal_tensor.contiguous();
-
-    printf("🔄 Metal->FLUX (passthrough BHSD): %s dtype=%s\n",
-           ("[" + std::to_string(flux_tensor.size(0)) + "," + std::to_string(flux_tensor.size(1)) + "," + std::to_string(flux_tensor.size(2)) + "," + std::to_string(flux_tensor.size(3)) + "]").c_str(),
-           scalar_type_to_string(flux_tensor.scalar_type()).c_str());
 
     return flux_tensor;
 }
@@ -1055,49 +1047,15 @@ torch::Tensor MetalSDPABackend::call_swift_flash_attention_impl(
         seq_len_kv = static_cast<uint32_t>(k_tensor.sizes()[2]);
         head_dim = static_cast<uint16_t>(q_metal_sizes[3]);
 
-        printf("📊 Regular attention dimensions (BHSD): batch=%u, heads=%u, seq_q=%u, seq_kv=%u, dim=%u\n",
-               batch_size, num_heads, seq_len_q, seq_len_kv, head_dim);
     } else {
         throw std::runtime_error("Unsupported tensor dimensions. Expected 2D (seq_len, head_dim) or 4D (batch, seq_len, num_heads, head_dim)");
     }
 
-    bool cpu_binding = !use_mps_buffers;
-    bool promoted_precision = false;
     auto original_input_dtype = q_tensor.scalar_type();
-
-    auto promote_to_fp32 = [&](torch::Tensor& tensor) {
-        if (tensor.scalar_type() == torch::kFloat16 || tensor.scalar_type() == torch::kBFloat16) {
-            tensor = tensor.to(torch::kFloat32);
-            promoted_precision = true;
-        }
-    };
-
-    promote_to_fp32(q_tensor);
-    promote_to_fp32(k_tensor);
-    promote_to_fp32(v_tensor);
-
-    // Synchronize after FP16→FP32 promotion — the .to(kFloat32) conversion
-    // is enqueued on PyTorch's MPS command queue, but UMFA's kernel reads
-    // the buffer via a separate Metal command queue. Without this sync, the
-    // first dispatch reads stale/uninitialised memory (producing zeros).
-    if (promoted_precision && use_mps_buffers) {
-        torch::mps::synchronize();
-    }
-
-    auto output = torch::empty_like(q_tensor);
-    auto describe_shape = [](const torch::Tensor& t) {
-        std::string s = "[";
-        for (int64_t i = 0; i < t.dim(); ++i) {
-            s += std::to_string(t.size(i));
-            if (i + 1 < t.dim()) s += ",";
-        }
-        s += "]";
-        return s;
-    };
-    printf("📋 Created output tensor: shape=%s dtype=%s\n",
-           describe_shape(output).c_str(),
-           scalar_type_to_string(output.scalar_type()).c_str());
-
+    auto output_dtype = original_input_dtype == torch::kFloat32
+        ? original_input_dtype
+        : torch::kFloat32;
+    auto output = torch::empty(q_tensor.sizes(), q_tensor.options().dtype(output_dtype));
     std::string precision_str;
     switch (q_tensor.scalar_type()) {
         case torch::kFloat16: precision_str = "fp16"; break;
@@ -1128,13 +1086,6 @@ torch::Tensor MetalSDPABackend::call_swift_flash_attention_impl(
 
     if (attn_mask.has_value() && attn_mask.value().defined()) {
         mask_cpu = ensure_contiguous_cpu(attn_mask.value());
-        if (promoted_precision) {
-            auto mask_dtype_for_conversion = mask_cpu.scalar_type();
-            if (mask_dtype_for_conversion == torch::kFloat16 || mask_dtype_for_conversion == torch::kBFloat16) {
-                mask_cpu = mask_cpu.to(torch::kFloat32);
-            }
-        }
-
         auto mask_dtype = mask_cpu.scalar_type();
         if (mask_dtype == torch::kBool) {
             mask_type = MFA_MASK_TYPE_BOOL;
@@ -1287,11 +1238,10 @@ torch::Tensor MetalSDPABackend::call_swift_flash_attention_impl(
     }
 
     if (input_was_flux) {
-        printf("🔄 Converting output from Metal layout [B,S,H,D] back to PyTorch layout [B,H,S,D]\n");
         output = convert_metal_to_flux_layout(output);
     }
 
-    if (promoted_precision) {
+    if (output.scalar_type() != original_input_dtype) {
         output = output.to(original_input_dtype);
     }
 
@@ -1345,6 +1295,327 @@ torch::Tensor MetalSDPABackend::call_swift_flash_attention(
     return call_swift_flash_attention_impl(q_cpu, k_cpu, v_cpu, mask_cpu, is_causal, softmax_scale, false);
 }
 
+torch::Tensor MetalSDPABackend::try_instream_flash_attention(
+    const torch::Tensor& q_in,
+    const torch::Tensor& k_in,
+    const torch::Tensor& v_in,
+    const c10::optional<torch::Tensor>& attn_mask,
+    bool is_causal,
+    float softmax_scale
+) {
+    // Kill switch for debugging: MFA_DISABLE_INSTREAM=1 forces the legacy
+    // synchronous dispatch path.
+    static const bool instream_disabled = []() {
+        const char* env = std::getenv("MFA_DISABLE_INSTREAM");
+        return env && env[0] == '1';
+    }();
+    if (instream_disabled || !swift_context_) {
+        return {};
+    }
+    if (!q_in.device().is_mps() || !k_in.device().is_mps() || !v_in.device().is_mps()) {
+        return {};
+    }
+    if (q_in.dim() != 4 || k_in.dim() != 4 || v_in.dim() != 4) {
+        return {};
+    }
+
+    const char* precision = nullptr;
+    switch (q_in.scalar_type()) {
+        case torch::kFloat16: precision = "fp16"; break;
+        case torch::kBFloat16: precision = "bf16"; break;
+        case torch::kFloat32: precision = "fp32"; break;
+        default: return {};
+    }
+    if (k_in.scalar_type() != q_in.scalar_type() ||
+        v_in.scalar_type() != q_in.scalar_type()) {
+        return {};
+    }
+
+    // Strided views ride the kernel's stride path when the last dim is
+    // contiguous and no stride is zero/negative (broadcast/flipped views
+    // still need a copy). Anything else gets a stream-ordered contiguous
+    // copy — no synchronization needed either way, the attention kernel is
+    // encoded on the same MPS stream after any copies. The kernel computes
+    // offsets in 32-bit, so very large strided extents fall back to a copy.
+    auto kernel_supports_strides = [](const torch::Tensor& t) {
+        if (t.is_contiguous()) {
+            return true;  // passed with null strides -> dense addressing
+        }
+        auto st = t.strides();
+        if (st[3] != 1) {
+            return false;
+        }
+        if (st[0] <= 0 || st[1] <= 0 || st[2] <= 0) {
+            return false;
+        }
+        const int64_t max_elem_offset =
+            (t.size(0) - 1) * st[0] + (t.size(1) - 1) * st[1] +
+            (t.size(2) - 1) * st[2] + (t.size(3) - 1) + t.storage_offset();
+        return max_elem_offset < (int64_t{1} << 31);
+    };
+    auto q = kernel_supports_strides(q_in) ? q_in : q_in.contiguous();
+    auto k = kernel_supports_strides(k_in) ? k_in : k_in.contiguous();
+    auto v = kernel_supports_strides(v_in) ? v_in : v_in.contiguous();
+
+    const auto q_sizes = q.sizes();  // BHSD
+    const int64_t batch = q_sizes[0];
+    const int64_t heads = q_sizes[1];
+    const int64_t seq_q = q_sizes[2];
+    const int64_t head_dim = q_sizes[3];
+    const int64_t seq_kv = k.size(2);
+    if (k.size(0) != batch || v.size(0) != batch ||
+        k.size(1) != heads || v.size(1) != heads ||
+        v.size(2) != seq_kv ||
+        k.size(3) != head_dim || v.size(3) != head_dim) {
+        return {};
+    }
+    if (seq_q > 65535 || seq_kv > 65535 || head_dim > 1024 || batch > 1024) {
+        return {};
+    }
+
+    torch::Tensor mask_tensor;
+    const torch::Tensor* mask_ptr = nullptr;
+    int mask_type = MFA_MASK_TYPE_NONE;
+    int mask_scalar_type = MFA_MASK_SCALAR_BYTE;
+    if (attn_mask.has_value() && attn_mask.value().defined()) {
+        mask_tensor = attn_mask.value();
+        if (!mask_tensor.device().is_mps() || mask_tensor.dim() == 0 || mask_tensor.dim() > 4) {
+            return {};
+        }
+        switch (mask_tensor.scalar_type()) {
+            case torch::kBool:
+                mask_type = MFA_MASK_TYPE_BOOL;
+                mask_scalar_type = MFA_MASK_SCALAR_BYTE;
+                break;
+            case torch::kFloat32:
+                mask_type = MFA_MASK_TYPE_ADDITIVE;
+                mask_scalar_type = MFA_MASK_SCALAR_FP32;
+                break;
+            case torch::kFloat16:
+                mask_type = MFA_MASK_TYPE_ADDITIVE;
+                mask_scalar_type = MFA_MASK_SCALAR_FP16;
+                break;
+            case torch::kBFloat16:
+                mask_type = MFA_MASK_TYPE_ADDITIVE;
+                mask_scalar_type = MFA_MASK_SCALAR_BF16;
+                break;
+            default:
+                return {};
+        }
+        mask_ptr = &mask_tensor;
+    }
+
+    // The kernel always stores O as FP32 (memoryPrecisions[.O] = .FP32), so
+    // the output buffer must be fp32 even for half-precision inputs; cast
+    // back afterwards. The cast is stream-ordered — still no host sync.
+    const auto orig_dtype = q.scalar_type();
+    const auto output_dtype = orig_dtype == torch::kFloat32 ? orig_dtype : torch::kFloat32;
+    auto output = torch::empty(q.sizes(), q.options().dtype(output_dtype));
+    int rc = mps_utils::encode_attention_on_torch_stream(
+        swift_context_,
+        q, k, v, output,
+        mask_ptr,
+        mask_type,
+        mask_scalar_type,
+        static_cast<uint32_t>(batch),
+        static_cast<uint32_t>(seq_q),
+        static_cast<uint32_t>(seq_kv),
+        static_cast<uint32_t>(heads),
+        static_cast<uint16_t>(head_dim),
+        softmax_scale,
+        is_causal,
+        precision,
+        precision);
+    if (rc != 0) {
+        return {};
+    }
+    if (output.scalar_type() != orig_dtype) {
+        output = output.to(orig_dtype);
+    }
+    return output;
+}
+
+
+namespace {
+
+// Eager interleaved-pair RoPE on BHSD tensors, fp32 math — bit-compatible
+// with diffusers apply_rotary_emb(use_real_unbind_dim=-1) given
+// pair-duplicated tables. Used as the fallback and the autograd-safe path.
+torch::Tensor apply_rope_eager_bhsd(
+    const torch::Tensor& x,
+    const torch::Tensor& cos_t,
+    const torch::Tensor& sin_t
+) {
+    auto cos_b = (cos_t.dim() == 2 ? cos_t.unsqueeze(0) : cos_t).unsqueeze(1);
+    auto sin_b = (sin_t.dim() == 2 ? sin_t.unsqueeze(0) : sin_t).unsqueeze(1);
+    auto xf = x.to(torch::kFloat32);
+    auto shape = xf.sizes().vec();
+    auto pairs = xf.reshape({shape[0], shape[1], shape[2], shape[3] / 2, 2});
+    auto x_real = pairs.select(-1, 0);
+    auto x_imag = pairs.select(-1, 1);
+    auto rotated = torch::stack({-x_imag, x_real}, -1).reshape(shape);
+    return (xf * cos_b + rotated * sin_b).to(x.scalar_type());
+}
+
+} // namespace
+
+torch::Tensor MetalSDPABackend::rope_scaled_dot_product_attention(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& rope_cos,
+    const torch::Tensor& rope_sin,
+    const c10::optional<torch::Tensor>& attn_mask,
+    bool is_causal,
+    c10::optional<double> scale
+) {
+    ensure_initialized();
+
+    auto eager = [&]() {
+        auto cos_f = rope_cos.to(query.device(), torch::kFloat32);
+        auto sin_f = rope_sin.to(query.device(), torch::kFloat32);
+        auto q_rot = apply_rope_eager_bhsd(query, cos_f, sin_f);
+        auto k_rot = apply_rope_eager_bhsd(key, cos_f, sin_f);
+        return scaled_dot_product_attention(
+            q_rot, k_rot, value, attn_mask, 0.0, is_causal, scale, true);
+    };
+
+    // v1 fused path is forward-only: attention backward returns gradients
+    // w.r.t. rotated Q/K, and the model needs pre-RoPE gradients (inverse
+    // rotation on dQ/dK). Until that autograd lands, gradient callers use
+    // the eager rotation, which flows through the existing autograd path.
+    const bool needs_grad = at::GradMode::is_enabled() &&
+        (query.requires_grad() || key.requires_grad() || value.requires_grad());
+    if (needs_grad) {
+        return eager();
+    }
+    if (!swift_context_ ||
+        !query.device().is_mps() || !key.device().is_mps() || !value.device().is_mps()) {
+        return eager();
+    }
+    if (query.dim() != 4 || key.dim() != 4 || value.dim() != 4) {
+        return eager();
+    }
+    const auto dt = query.scalar_type();
+    if (dt != torch::kFloat32 && dt != torch::kFloat16 && dt != torch::kBFloat16) {
+        return eager();
+    }
+    if (key.scalar_type() != dt || value.scalar_type() != dt) {
+        return eager();
+    }
+
+    const int64_t B = query.size(0);
+    const int64_t Hq = query.size(1);
+    const int64_t Sq = query.size(2);
+    const int64_t D = query.size(3);
+    const int64_t Hkv = key.size(1);
+    const int64_t Skv = key.size(2);
+    if (D % 2 != 0 || D > 1024 || Sq > 65535 || Skv > 65535 || B > 1024) {
+        return eager();
+    }
+    if (key.size(0) != B || value.size(0) != B || value.size(1) != Hkv ||
+        value.size(2) != Skv || key.size(3) != D || value.size(3) != D) {
+        return eager();
+    }
+    if (Hq != Hkv && (Hkv == 0 || Hq % Hkv != 0)) {
+        return eager();
+    }
+    // All four target models are joint self-attention: one table covers the
+    // shared sequence. Cross-length rope needs per-tensor tables — later.
+    if (Sq != Skv) {
+        return eager();
+    }
+
+    // Normalize tables to fp32 contiguous MPS: [S, D] (shared) or [B, S, D].
+    auto normalize_table = [&](const torch::Tensor& t) -> torch::Tensor {
+        auto out = t;
+        if (out.dim() == 3 && out.size(0) == 1) {
+            out = out.squeeze(0);
+        }
+        return out.to(query.device(), torch::kFloat32).contiguous();
+    };
+    auto cos_t = normalize_table(rope_cos);
+    auto sin_t = normalize_table(rope_sin);
+    if (cos_t.sizes() != sin_t.sizes()) {
+        return eager();
+    }
+    int64_t table_batch_stride = 0;
+    if (cos_t.dim() == 2) {
+        if (cos_t.size(0) < Sq || cos_t.size(1) != D) {
+            return eager();
+        }
+    } else if (cos_t.dim() == 3) {
+        if (cos_t.size(0) != B || cos_t.size(1) < Sq || cos_t.size(2) != D) {
+            return eager();
+        }
+        table_batch_stride = cos_t.size(1) * D;
+    } else {
+        return eager();
+    }
+    // Table rows are indexed as s * D, so rows beyond Sq are simply unused;
+    // a 2D table with more rows than Sq is fine, a batched one too.
+
+    const char* precision = dt == torch::kFloat16 ? "fp16"
+        : dt == torch::kBFloat16                  ? "bf16"
+                                                  : "fp32";
+
+    // The rotation kernel reads strided BHSD views directly when the last
+    // dim is contiguous; otherwise copy (stream-ordered, no sync).
+    auto rope_src_ok = [](const torch::Tensor& t) {
+        if (t.is_contiguous()) {
+            return true;
+        }
+        auto st = t.strides();
+        return st[3] == 1 && st[0] >= 0 && st[1] >= 0 && st[2] >= 0;
+    };
+    auto q_src = rope_src_ok(query) ? query : query.contiguous();
+    auto k_src = rope_src_ok(key) ? key : key.contiguous();
+
+    auto q_rot = torch::empty({B, Hq, Sq, D}, query.options());
+    auto k_rot = torch::empty({B, Hkv, Skv, D}, key.options());
+
+    int rc = mps_utils::encode_rope_rotate_on_torch_stream(
+        swift_context_, q_src, q_rot, cos_t, sin_t,
+        table_batch_stride, /*negate_sin=*/false,
+        static_cast<uint32_t>(B), static_cast<uint32_t>(Hq),
+        static_cast<uint32_t>(Sq), static_cast<uint32_t>(D), precision);
+    if (rc == 0) {
+        rc = mps_utils::encode_rope_rotate_on_torch_stream(
+            swift_context_, k_src, k_rot, cos_t, sin_t,
+            table_batch_stride, /*negate_sin=*/false,
+            static_cast<uint32_t>(B), static_cast<uint32_t>(Hkv),
+            static_cast<uint32_t>(Skv), static_cast<uint32_t>(D), precision);
+    }
+    if (rc != 0) {
+        // Nothing has been committed; any encoded rotation only writes the
+        // scratch tensors we are about to drop. Correctness via eager path.
+        return eager();
+    }
+
+    torch::Tensor k_in = k_rot;
+    torch::Tensor v_in = value;
+    if (Hq != Hkv) {
+        const int64_t group = Hq / Hkv;
+        k_in = k_rot.repeat_interleave(group, 1);
+        v_in = value.repeat_interleave(group, 1);
+    }
+
+    float softmax_scale = scale.has_value()
+        ? static_cast<float>(scale.value())
+        : 1.0f / std::sqrt(static_cast<float>(D));
+
+    auto result = try_instream_flash_attention(
+        q_rot, k_in, v_in, attn_mask, is_causal, softmax_scale);
+    if (!result.defined()) {
+        // Attention declined (mask type, shape, ...). The rotations are
+        // already encoded and correct — route the rotated tensors through
+        // the full dispatcher instead of redoing rope eagerly.
+        return scaled_dot_product_attention(
+            q_rot, k_in, v_in, attn_mask, 0.0, is_causal, scale, false);
+    }
+    dispatch_stats().rope_instream.fetch_add(1, std::memory_order_relaxed);
+    return result;
+}
 
 torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
     const torch::Tensor& query,
@@ -1474,6 +1745,9 @@ torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
     bool needs_autograd = q.requires_grad() || k.requires_grad() ||
                           v.requires_grad();
     if (needs_autograd) {
+        if (is_causal) {
+            return fallback_to_native();
+        }
         stats.fp32_autograd.fetch_add(1, std::memory_order_relaxed);
         return metal_flash_attention_autograd(
             q, k, v, is_causal, sm_scale);
@@ -1511,14 +1785,42 @@ torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
     auto orig_device = q.device();
     auto orig_dtype = q.scalar_type();
 
-    // Call Swift Flash Attention (using processed tensors from call_swift_flash_attention)
-    stats.fp32_direct.fetch_add(1, std::memory_order_relaxed);
-    auto result = call_swift_flash_attention(q, k, v, attn_mask, is_causal, softmax_scale);
+    // Eligible calls encode straight into PyTorch's MPS stream: no entry
+    // sync, no dtype promotion, no waitUntilCompleted. Real masks are
+    // expanded on the same stream before attention. Anything the in-stream
+    // path declines uses the legacy synchronous path.
+    torch::Tensor result;
+    bool used_instream = false;
+    result = try_instream_flash_attention(
+        q, k, v,
+        has_real_mask ? attn_mask : c10::optional<torch::Tensor>(),
+        is_causal,
+        softmax_scale);
+    used_instream = result.defined();
+    if (used_instream) {
+        stats.fp32_instream.fetch_add(1, std::memory_order_relaxed);
+    } else {
+        stats.fp32_direct.fetch_add(1, std::memory_order_relaxed);
+        result = call_swift_flash_attention(
+            q, k, v,
+            has_real_mask ? attn_mask : c10::optional<torch::Tensor>(),
+            is_causal,
+            softmax_scale);
+    }
 
-    // Runtime NaN safety net — certain head_dim values trigger a kernel bug
-    // (likely in block dimension padding). Fall back to PyTorch native.
-    if (torch::isnan(result).any().item<bool>()) {
-        stats.fp32_direct.fetch_sub(1, std::memory_order_relaxed);
+    // Runtime NaN safety net, opt-in via MFA_NAN_CHECK=1. The check forces a
+    // blocking GPU sync per call, which defeats the async in-stream path —
+    // keep it for debugging suspected kernel issues only.
+    static const bool nan_check_enabled = []() {
+        const char* env = std::getenv("MFA_NAN_CHECK");
+        return env && env[0] == '1';
+    }();
+    if (nan_check_enabled && torch::isnan(result).any().item<bool>()) {
+        if (used_instream) {
+            stats.fp32_instream.fetch_sub(1, std::memory_order_relaxed);
+        } else {
+            stats.fp32_direct.fetch_sub(1, std::memory_order_relaxed);
+        }
         stats.pytorch_fallback.fetch_add(1, std::memory_order_relaxed);
         return at::native::scaled_dot_product_attention(
             query, key, value, native_safe_mask(), dropout_p, is_causal, scale, enable_gqa);
@@ -2328,14 +2630,10 @@ public:
       throw std::runtime_error("Metal SDPA backend not initialized");
     }
 
-    // Promote fp16/bf16 → fp32, make contiguous BHSD.
+    // Keep fp16/bf16 inputs in their native memory format; the Swift
+    // descriptor now carries the actual input precision.
     auto orig_dtype = query.scalar_type();
-    if (query.scalar_type() == torch::kFloat16 ||
-        query.scalar_type() == torch::kBFloat16) {
-      query = query.to(torch::kFloat32);
-      key = key.to(torch::kFloat32);
-      value = value.to(torch::kFloat32);
-    }
+    auto input_precision = MetalSDPABackend::torch_dtype_to_mfa_dtype(orig_dtype);
     query = query.contiguous();
     key = key.contiguous();
     value = value.contiguous();
@@ -2355,7 +2653,8 @@ public:
       sm_scale = 1.0f / std::sqrt(static_cast<float>(dim));
     }
 
-    auto output = torch::empty_like(query);
+    auto output_dtype = orig_dtype == torch::kFloat32 ? orig_dtype : torch::kFloat32;
+    auto output = torch::empty(query.sizes(), query.options().dtype(output_dtype));
     auto lse = torch::empty(
         {batch * heads * seq_q}, torch::kFloat32).to(query.device());
 
@@ -2377,6 +2676,7 @@ public:
         q_b, k_b, v_b, out_b, lse_b,
         batch, seq_q, seq_kv, heads, dim,
         sm_scale, is_causal,
+        input_precision, input_precision,
         false, false, false, false);
 
     mfa_destroy_buffer(q_b);
@@ -2391,9 +2691,9 @@ public:
           std::to_string(result));
     }
 
-    // Convert back to original dtype.
+    auto returned_output = output;
     if (output.scalar_type() != orig_dtype) {
-      output = output.to(orig_dtype);
+      returned_output = output.to(orig_dtype);
     }
 
     ctx->save_for_backward({query, key, value, output});
@@ -2401,8 +2701,9 @@ public:
     ctx->saved_data["scale"] = sm_scale;
     ctx->saved_data["is_causal"] = is_causal;
     ctx->saved_data["orig_dtype"] = static_cast<int64_t>(orig_dtype);
+    ctx->saved_data["input_precision"] = static_cast<int64_t>(input_precision);
 
-    return output;
+    return returned_output;
   }
 
   static torch::autograd::tensor_list backward(
@@ -2421,10 +2722,12 @@ public:
     auto d_output = grad_outputs[0];
     auto orig_dtype = static_cast<torch::ScalarType>(
         ctx->saved_data["orig_dtype"].toInt());
+    auto input_precision = static_cast<mfa_precision_t>(
+        ctx->saved_data["input_precision"].toInt());
 
-    // Promote grad to fp32 + contiguous.
-    if (d_output.scalar_type() != torch::kFloat32) {
-      d_output = d_output.to(torch::kFloat32);
+    auto d_output_dtype = orig_dtype == torch::kFloat32 ? torch::kFloat32 : orig_dtype;
+    if (d_output.scalar_type() != d_output_dtype) {
+      d_output = d_output.to(d_output_dtype);
     }
     d_output = d_output.contiguous();
 
@@ -2440,14 +2743,14 @@ public:
     }
 
     auto mfa_ctx = MetalSDPABackend::get_swift_context();
-    auto d_query = torch::zeros_like(query);
-    auto d_key = torch::zeros_like(key);
-    auto d_value = torch::zeros_like(value);
+    auto fp32_options = query.options().dtype(torch::kFloat32);
+    auto d_query = torch::zeros(query.sizes(), fp32_options);
+    auto d_key = torch::zeros(key.sizes(), fp32_options);
+    auto d_value = torch::zeros(value.sizes(), fp32_options);
     auto d_buffer = torch::zeros(
         {batch * heads * seq_q}, torch::kFloat32).to(query.device());
 
-    // Forward output needs to be fp32 for the backward kernel.
-    auto output_fp32 = saved[3].to(torch::kFloat32);
+    auto output_fp32 = saved[3];
 
     auto bind = [&](torch::Tensor &t) -> mfa_buffer_t {
       mfa_buffer_t h = nullptr;
@@ -2472,6 +2775,7 @@ public:
         dq_b, dk_b, dv_b, d_b,
         batch, seq_q, seq_kv, heads, dim,
         sm_scale, is_causal,
+        input_precision, input_precision,
         false, false, false, false);
 
     mfa_destroy_buffer(dout_b);
@@ -2775,6 +3079,8 @@ std::map<std::string, int64_t> get_dispatch_stats() {
         {"quantized_autograd", s.quantized_autograd.load(std::memory_order_relaxed)},
         {"fp32_autograd", s.fp32_autograd.load(std::memory_order_relaxed)},
         {"fp32_direct", s.fp32_direct.load(std::memory_order_relaxed)},
+        {"fp32_instream", s.fp32_instream.load(std::memory_order_relaxed)},
+        {"rope_instream", s.rope_instream.load(std::memory_order_relaxed)},
         {"pytorch_fallback", s.pytorch_fallback.load(std::memory_order_relaxed)},
         {"mask_all_true_skipped", s.mask_all_true_skipped.load(std::memory_order_relaxed)},
     };
@@ -2786,6 +3092,8 @@ void reset_dispatch_stats() {
     s.quantized_autograd.store(0);
     s.fp32_autograd.store(0);
     s.fp32_direct.store(0);
+    s.fp32_instream.store(0);
+    s.rope_instream.store(0);
     s.pytorch_fallback.store(0);
     s.mask_all_true_skipped.store(0);
 }
@@ -2799,4 +3107,8 @@ void reset_dispatch_stats() {
 // calls on MPS tensors.
 TORCH_LIBRARY_IMPL(aten, MPS, m) {
     m.impl("scaled_dot_product_attention", &metal_sdpa::MetalSDPABackend::scaled_dot_product_attention);
+}
+
+TORCH_LIBRARY_IMPL(aten, AutogradMPS, m) {
+    m.impl("scaled_dot_product_attention", torch::CppFunction::makeFallthrough());
 }

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -1361,7 +1361,73 @@ torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
         auto& stats = dispatch_stats();
         stats.total.fetch_add(1, std::memory_order_relaxed);
 
+    torch::Tensor q = query;
+    torch::Tensor k = key;
+    torch::Tensor v = value;
+
+    // GQA expansion: if Q has more heads than K/V, expand K/V by repeating
+    // each KV head Hq/Hkv times. Matches PyTorch's native GQA behavior.
+    if (q.dim() >= 3 && k.dim() >= 3 && q.size(-3) != k.size(-3)) {
+        int64_t Hq = q.size(-3);
+        int64_t Hkv = k.size(-3);
+        if (Hq > Hkv && Hq % Hkv == 0) {
+            int64_t group = Hq / Hkv;
+            k = k.repeat_interleave(group, -3).contiguous();
+            v = v.repeat_interleave(group, -3).contiguous();
+        }
+    }
+
     double sm_scale = scale.value_or(0.0);
+
+    auto fallback_to_native = [&]() {
+        stats.pytorch_fallback.fetch_add(1, std::memory_order_relaxed);
+        return at::native::scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            attn_mask,
+            dropout_p,
+            is_causal,
+            scale,
+            enable_gqa
+        );
+    };
+
+    auto unsupported_shape_or_dtype = [&]() {
+        if (q.device().type() != at::kMPS ||
+            k.device().type() != at::kMPS ||
+            v.device().type() != at::kMPS) {
+            return true;
+        }
+        if (q.dim() != 4 || k.dim() != 4 || v.dim() != 4) {
+            return true;
+        }
+        if (q.size(0) != k.size(0) ||
+            q.size(0) != v.size(0) ||
+            q.size(1) != k.size(1) ||
+            q.size(1) != v.size(1) ||
+            q.size(3) != k.size(3) ||
+            q.size(3) != v.size(3)) {
+            return true;
+        }
+        if (q.scalar_type() != torch::kFloat32 &&
+            q.scalar_type() != torch::kFloat16 &&
+            q.scalar_type() != torch::kBFloat16) {
+            return true;
+        }
+        if (k.scalar_type() != q.scalar_type() ||
+            v.scalar_type() != q.scalar_type()) {
+            return true;
+        }
+        if (q.size(1) < 4 || q.size(2) < 64) {
+            return true;
+        }
+        return false;
+    };
+
+    if (unsupported_shape_or_dtype() || dropout_p > 0.0) {
+        return fallback_to_native();
+    }
 
     // ---- Detect trivially all-true bool masks ----
     // Many models (e.g. Z-Image) always pass an encoder_attention_mask even
@@ -1387,19 +1453,19 @@ torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
     if (quant_precision().load() != 0) {
         stats.quantized_autograd.fetch_add(1, std::memory_order_relaxed);
         return metal_quantized_flash_attention_autograd(
-            query, key, value, is_causal, sm_scale,
+            q, k, v, is_causal, sm_scale,
             static_cast<int64_t>(quant_precision().load()),
             static_cast<int64_t>(quant_block_mode().load()),
             has_real_mask ? attn_mask : c10::optional<torch::Tensor>());
     }
 
     // ---- Route to FP32 autograd when inputs require grad ----
-    bool needs_autograd = query.requires_grad() || key.requires_grad() ||
-                          value.requires_grad();
+    bool needs_autograd = q.requires_grad() || k.requires_grad() ||
+                          v.requires_grad();
     if (needs_autograd) {
         stats.fp32_autograd.fetch_add(1, std::memory_order_relaxed);
         return metal_flash_attention_autograd(
-            query, key, value, is_causal, sm_scale);
+            q, k, v, is_causal, sm_scale);
     }
 
     // ---- Remaining paths: direct UMFA (no autograd) or PyTorch fallback ----
@@ -1416,22 +1482,8 @@ torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
             mask_dtype != torch::kFloat32 &&
             mask_dtype != torch::kFloat16 &&
             mask_dtype != torch::kBFloat16) {
-            stats.pytorch_fallback.fetch_add(1, std::memory_order_relaxed);
-            return at::native::scaled_dot_product_attention(
-                query,
-                key,
-                value,
-                attn_mask,
-                dropout_p,
-                is_causal,
-                scale,
-                enable_gqa
-            );
+            return fallback_to_native();
         }
-    }
-
-    if (enable_gqa) {
-        std::cout << "Warning: Grouped Query Attention (GQA) not yet supported, ignoring enable_gqa flag" << std::endl;
     }
 
     // Calculate softmax scale
@@ -1440,17 +1492,17 @@ torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
         softmax_scale = static_cast<float>(scale.value());
     } else {
         // Default: 1/sqrt(head_dim)
-        int head_dim = query.size(-1);
+        int head_dim = q.size(-1);
         softmax_scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
     }
 
     // Store original device and dtype
-    auto orig_device = query.device();
-    auto orig_dtype = query.scalar_type();
+    auto orig_device = q.device();
+    auto orig_dtype = q.scalar_type();
 
     // Call Swift Flash Attention (using processed tensors from call_swift_flash_attention)
     stats.fp32_direct.fetch_add(1, std::memory_order_relaxed);
-    auto result = call_swift_flash_attention(query, key, value, attn_mask, is_causal, softmax_scale);
+    auto result = call_swift_flash_attention(q, k, v, attn_mask, is_causal, softmax_scale);
 
     // Convert result back to original layout if input was FLUX
     // Note: The layout conversion is now handled within call_swift_flash_attention

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -8,6 +8,7 @@
 #include <c10/util/Exception.h>
 #include <mutex>
 #include <unordered_set>
+#include <map>
 #include <stdexcept>
 #include <iostream>
 #include <cinttypes>  // For PRId64, PRIu32, etc.
@@ -1347,43 +1348,64 @@ torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
     bool enable_gqa
 ) {
     try {
-        // Ensure backend is initialized
         ensure_initialized();
+        auto& stats = dispatch_stats();
+        stats.total.fetch_add(1, std::memory_order_relaxed);
 
     double sm_scale = scale.value_or(0.0);
-    bool has_mask = attn_mask.has_value() && attn_mask.value().defined();
 
-    // Route to quantized autograd when INT8/INT4 mode is active.
-    if (quant_precision().load() != 0 && !has_mask) {
+    // ---- Detect trivially all-true bool masks ----
+    // Many models (e.g. Z-Image) always pass an encoder_attention_mask even
+    // when every position is attended. An all-true bool mask is semantically
+    // a no-op, so we strip it and route through the fast path.
+    bool has_real_mask = false;
+    if (attn_mask.has_value() && attn_mask.value().defined()) {
+        auto& mask = attn_mask.value();
+        if (mask.scalar_type() == torch::kBool && mask.numel() > 0) {
+            if (mask.all().item<bool>()) {
+                // All-true mask — skip it.
+                stats.mask_all_true_skipped.fetch_add(1, std::memory_order_relaxed);
+            } else {
+                has_real_mask = true;
+            }
+        } else {
+            has_real_mask = true;
+        }
+    }
+
+    // ---- Route to quantized autograd when INT8/INT4 mode is active ----
+    if (quant_precision().load() != 0 && !has_real_mask) {
+        stats.quantized_autograd.fetch_add(1, std::memory_order_relaxed);
         return metal_quantized_flash_attention_autograd(
             query, key, value, is_causal, sm_scale,
             static_cast<int64_t>(quant_precision().load()),
             static_cast<int64_t>(quant_block_mode().load()));
     }
 
-    // Route to FP32 autograd when inputs require grad and no mask.
-    // This ensures gradients flow through F.scaled_dot_product_attention
-    // at the dispatcher level (otherwise PyTorch warns about missing
-    // autograd kernels).
+    // ---- Route to FP32 autograd when inputs require grad ----
     bool needs_autograd = query.requires_grad() || key.requires_grad() ||
                           value.requires_grad();
-    if (needs_autograd && !has_mask) {
+    if (needs_autograd && !has_real_mask) {
+        stats.fp32_autograd.fetch_add(1, std::memory_order_relaxed);
         return metal_flash_attention_autograd(
             query, key, value, is_causal, sm_scale);
     }
+
+    // ---- Remaining paths: direct UMFA (no autograd) or PyTorch fallback ----
+    // These paths handle masks that aren't all-true.
 
     // Validate inputs
     if (dropout_p > 0.0) {
         std::cout << "Warning: Dropout not supported in Metal Flash Attention, ignoring dropout_p" << std::endl;
     }
 
-    if (attn_mask.has_value() && attn_mask.value().defined()) {
+    if (has_real_mask) {
         auto mask_dtype = attn_mask.value().scalar_type();
         if (mask_dtype != torch::kBool &&
             mask_dtype != torch::kFloat32 &&
             mask_dtype != torch::kFloat16 &&
             mask_dtype != torch::kBFloat16) {
-            std::cout << "⚠️  Unsupported attention mask dtype for Metal backend, using PyTorch reference implementation" << std::endl;
+            stats.pytorch_fallback.fetch_add(1, std::memory_order_relaxed);
             return at::native::scaled_dot_product_attention(
                 query,
                 key,
@@ -1416,6 +1438,7 @@ torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
     auto orig_dtype = query.scalar_type();
 
     // Call Swift Flash Attention (using processed tensors from call_swift_flash_attention)
+    stats.fp32_direct.fetch_add(1, std::memory_order_relaxed);
     auto result = call_swift_flash_attention(query, key, value, attn_mask, is_causal, softmax_scale);
 
     // Convert result back to original layout if input was FLUX
@@ -2597,6 +2620,28 @@ void set_quantization_mode(int64_t precision, int64_t block_mode) {
 
 void clear_quantization_mode() {
     MetalSDPABackend::quant_precision().store(0);
+}
+
+std::map<std::string, int64_t> get_dispatch_stats() {
+    auto& s = MetalSDPABackend::dispatch_stats();
+    return {
+        {"total", s.total.load(std::memory_order_relaxed)},
+        {"quantized_autograd", s.quantized_autograd.load(std::memory_order_relaxed)},
+        {"fp32_autograd", s.fp32_autograd.load(std::memory_order_relaxed)},
+        {"fp32_direct", s.fp32_direct.load(std::memory_order_relaxed)},
+        {"pytorch_fallback", s.pytorch_fallback.load(std::memory_order_relaxed)},
+        {"mask_all_true_skipped", s.mask_all_true_skipped.load(std::memory_order_relaxed)},
+    };
+}
+
+void reset_dispatch_stats() {
+    auto& s = MetalSDPABackend::dispatch_stats();
+    s.total.store(0);
+    s.quantized_autograd.store(0);
+    s.fp32_autograd.store(0);
+    s.fp32_direct.store(0);
+    s.pytorch_fallback.store(0);
+    s.mask_all_true_skipped.store(0);
 }
 
 } // namespace metal_sdpa

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -1379,13 +1379,27 @@ torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
 
     double sm_scale = scale.value_or(0.0);
 
+    // PyTorch's MPS math fallback promotes the query to FP32 internally and
+    // then rejects FP16/BF16 masks ("attn_mask dtype ... to match query
+    // dtype"). FP32 masks are always accepted, so upcast before falling back.
+    auto native_safe_mask = [&]() -> c10::optional<torch::Tensor> {
+        if (!attn_mask.has_value() || !attn_mask.value().defined()) {
+            return attn_mask;
+        }
+        auto mask_dtype = attn_mask.value().scalar_type();
+        if (mask_dtype == torch::kFloat16 || mask_dtype == torch::kBFloat16) {
+            return attn_mask.value().to(torch::kFloat32);
+        }
+        return attn_mask;
+    };
+
     auto fallback_to_native = [&]() {
         stats.pytorch_fallback.fetch_add(1, std::memory_order_relaxed);
         return at::native::scaled_dot_product_attention(
             query,
             key,
             value,
-            attn_mask,
+            native_safe_mask(),
             dropout_p,
             is_causal,
             scale,
@@ -1507,7 +1521,7 @@ torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
         stats.fp32_direct.fetch_sub(1, std::memory_order_relaxed);
         stats.pytorch_fallback.fetch_add(1, std::memory_order_relaxed);
         return at::native::scaled_dot_product_attention(
-            query, key, value, attn_mask, dropout_p, is_causal, scale, enable_gqa);
+            query, key, value, native_safe_mask(), dropout_p, is_causal, scale, enable_gqa);
     }
 
     // Convert result back to original layout if input was FLUX

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -1970,10 +1970,26 @@ torch::Tensor MetalSDPABackend::quantized_scaled_dot_product_attention_unified(
         }
     }
 
-    // Convert all tensors to CPU and contiguous
-    auto q_cpu = MetalSDPABackend::ensure_contiguous_cpu(query);
-    auto k_cpu = MetalSDPABackend::ensure_contiguous_cpu(key);
-    auto v_cpu = MetalSDPABackend::ensure_contiguous_cpu(value);
+    // Stage tensors for the kernel. On MPS, keep them on-device and bind their
+    // MTLBuffers directly like the regular path — wrapping CPU malloc memory
+    // with makeBuffer(bytesNoCopy:) is unreliable (intermittent NaN on first
+    // dispatch). Promote to FP32 here: the Swift kernel reads FP32.
+    // Synchronize around the on-device conversions so UMFA's separate Metal
+    // command queue doesn't read the buffers before PyTorch's queue has
+    // finished writing them.
+    bool use_mps_buffers = query.device().is_mps() && key.device().is_mps() && value.device().is_mps();
+    torch::Tensor q_cpu, k_cpu, v_cpu;
+    if (use_mps_buffers) {
+        torch::mps::synchronize();
+        q_cpu = query.contiguous().to(torch::kFloat32);
+        k_cpu = key.contiguous().to(torch::kFloat32);
+        v_cpu = value.contiguous().to(torch::kFloat32);
+        torch::mps::synchronize();
+    } else {
+        q_cpu = MetalSDPABackend::ensure_contiguous_cpu(query).to(torch::kFloat32);
+        k_cpu = MetalSDPABackend::ensure_contiguous_cpu(key).to(torch::kFloat32);
+        v_cpu = MetalSDPABackend::ensure_contiguous_cpu(value).to(torch::kFloat32);
+    }
 
     // Detect tensor layout and convert if necessary
     printf("🔍 Analyzing tensor layouts for FLUX compatibility...\n");
@@ -2003,15 +2019,17 @@ torch::Tensor MetalSDPABackend::quantized_scaled_dot_product_attention_unified(
         v_metal = convert_flux_to_metal_layout(v_cpu);
     }
 
-    // Get tensor dimensions (now in Metal layout [B,S,H,D])
+    // Get tensor dimensions. The layout "conversion" above is a passthrough
+    // (the kernel consumes contiguous BHSD directly), and PyTorch SDPA inputs
+    // are always [B, H, S, D] — extract dimensions accordingly.
     uint32_t batch_size, seq_len_q, seq_len_kv, num_heads, head_dim;
 
     if (q_metal.dim() == 4) {
         auto q_sizes = q_metal.sizes();
         batch_size = static_cast<uint32_t>(q_sizes[0]);
-        seq_len_q = static_cast<uint32_t>(q_sizes[1]);
-        seq_len_kv = static_cast<uint32_t>(k_metal.sizes()[1]);
-        num_heads = static_cast<uint32_t>(q_sizes[2]);
+        num_heads = static_cast<uint32_t>(q_sizes[1]);
+        seq_len_q = static_cast<uint32_t>(q_sizes[2]);
+        seq_len_kv = static_cast<uint32_t>(k_metal.sizes()[2]);
         head_dim = static_cast<uint16_t>(q_sizes[3]);
 
         printf("📊 Final tensor dimensions: batch=%u, seq_q=%u, seq_kv=%u, heads=%u, dim=%u\n",
@@ -2029,8 +2047,11 @@ torch::Tensor MetalSDPABackend::quantized_scaled_dot_product_attention_unified(
         throw std::runtime_error("Unified quantized attention currently only supports 4D tensors [batch, seq_len, num_heads, head_dim]");
     }
 
-    // Determine optimal output precision using intelligent selection
-    OutputPrecision optimal_output_precision = metal_sdpa::determine_output_precision(effective_config, q_metal, k_metal, v_metal);
+    // The Swift entry point (mfa_attention_forward_quantized_direct) dispatches
+    // MultiHeadAttention with default precisions: it reads Q/K/V as FP32 and
+    // writes FP32 output, ignoring the precision parameters. Feed it FP32 and
+    // cast back to the caller's dtype at the end.
+    OutputPrecision optimal_output_precision = OutputPrecision::FP32;
 
     // Create type-safe output tensor with validation (using Metal layout)
     auto output = metal_sdpa::create_typed_output_tensor(q_metal, optimal_output_precision, true);
@@ -2043,40 +2064,39 @@ torch::Tensor MetalSDPABackend::quantized_scaled_dot_product_attention_unified(
     // The new runtime quantization API handles all quantization on the GPU side
     printf("🚀 Using runtime quantization - bypassing C++ side quantization\n");
 
-    // No longer quantize tensors on C++ side - pass raw FP16/BF16/FP32 tensors directly
+    // Tensors were already promoted to FP32 during staging above.
     torch::Tensor q_processed = q_metal;
     torch::Tensor k_processed = k_metal;
     torch::Tensor v_processed = v_metal;
 
-    // Create MFA buffers
+    // Create MFA buffers. On MPS, bind the tensors' MTLBuffers directly
+    // (same mechanism as the regular path); on CPU, wrap the host pointers.
     mfa_buffer_t q_buffer, k_buffer, v_buffer, out_buffer;
 
-    size_t q_bytes = q_processed.numel() * q_processed.element_size();
-    size_t k_bytes = k_processed.numel() * k_processed.element_size();
-    size_t v_bytes = v_processed.numel() * v_processed.element_size();
-    size_t out_bytes = output.storage().nbytes();
+    auto bind_buffer = [&](const char* name, const torch::Tensor& tensor, mfa_buffer_t& buffer) {
+        size_t bytes = tensor.numel() * tensor.element_size();
+        mfa_error_t bind_result;
+        if (use_mps_buffers) {
+            void* handle = mps_utils::get_mtl_buffer_handle(tensor);
+            if (!handle) {
+                throw std::runtime_error(std::string("Failed to acquire MTLBuffer for ") + name + " in unified quantized attention");
+            }
+            bind_result = mfa_buffer_from_mtl_buffer(MetalSDPABackend::swift_context_, handle, bytes, &buffer);
+        } else {
+            bind_result = mfa_buffer_from_ptr(MetalSDPABackend::swift_context_, tensor.data_ptr(), bytes, &buffer);
+        }
+        if (bind_result != MFA_SUCCESS) {
+            throw std::runtime_error(std::string("Failed to create ") + name + " buffer for unified quantized attention");
+        }
+    };
 
     mfa_error_t result;
 
-    result = mfa_buffer_from_ptr(MetalSDPABackend::swift_context_, q_processed.data_ptr(), q_bytes, &q_buffer);
-    if (result != MFA_SUCCESS) {
-        throw std::runtime_error("Failed to create query buffer for unified quantized attention");
-    }
+    bind_buffer("query", q_processed, q_buffer);
+    bind_buffer("key", k_processed, k_buffer);
+    bind_buffer("value", v_processed, v_buffer);
 
-    result = mfa_buffer_from_ptr(MetalSDPABackend::swift_context_, k_processed.data_ptr(), k_bytes, &k_buffer);
-    if (result != MFA_SUCCESS) {
-        throw std::runtime_error("Failed to create key buffer for unified quantized attention");
-    }
-
-    result = mfa_buffer_from_ptr(MetalSDPABackend::swift_context_, v_processed.data_ptr(), v_bytes, &v_buffer);
-    if (result != MFA_SUCCESS) {
-        throw std::runtime_error("Failed to create value buffer for unified quantized attention");
-    }
-
-    result = mfa_buffer_from_ptr(MetalSDPABackend::swift_context_, output.data_ptr(), out_bytes, &out_buffer);
-    if (result != MFA_SUCCESS) {
-        throw std::runtime_error("Failed to create output buffer for unified quantized attention");
-    }
+    bind_buffer("output", output, out_buffer);
 
     try {
         // Convert effective granularity enum to int32_t for FFI
@@ -2185,8 +2205,8 @@ torch::Tensor MetalSDPABackend::quantized_scaled_dot_product_attention_unified(
         printf("🧹 Creating safe copy of output tensor before buffer cleanup...\n");
         torch::Tensor safe_output = final_output.clone().contiguous();
 
-        // Convert to target device AFTER creating safe copy
-        torch::Tensor final_result = safe_output.to(query.device());
+        // Convert to target device and the caller's dtype AFTER creating safe copy
+        torch::Tensor final_result = safe_output.to(query.device(), query.scalar_type());
 
         // Now safe to clean up MFA buffers since we have an independent copy
         printf("🧹 Skipping MFA buffer destruction (zero-copy views are owned by PyTorch)\n");

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -1651,6 +1651,36 @@ torch::Tensor MetalSDPABackend::scaled_dot_product_attention(
 ) {
     try {
         ensure_initialized();
+
+        TORCH_CHECK(
+            key.dim() == value.dim() && key.dim() >= 2 &&
+                key.size(-2) == value.size(-2),
+            "Metal SDPA: key and value must have matching sequence lengths");
+
+        // PyTorch SDPA accepts 2D (S, E) and 3D (N, S, E) inputs, but the
+        // kernels and torch's own MPS math fallback assume 4D BHSD (the
+        // math_mps path indexes dim 3 unconditionally and throws on
+        // anything smaller). Normalize to 4D here and strip the added
+        // leading dims from the result — this also routes small-rank calls
+        // through the real UMFA path instead of the fallback.
+        if (query.dim() >= 2 && query.dim() < 4 &&
+            key.dim() == query.dim() && value.dim() == query.dim()) {
+            auto q4 = query;
+            auto k4 = key;
+            auto v4 = value;
+            while (q4.dim() < 4) {
+                q4 = q4.unsqueeze(0);
+                k4 = k4.unsqueeze(0);
+                v4 = v4.unsqueeze(0);
+            }
+            auto out = scaled_dot_product_attention(
+                q4, k4, v4, attn_mask, dropout_p, is_causal, scale, enable_gqa);
+            for (int64_t i = query.dim(); i < 4; ++i) {
+                out = out.squeeze(0);
+            }
+            return out;
+        }
+
         auto& stats = dispatch_stats();
         stats.total.fetch_add(1, std::memory_order_relaxed);
 

--- a/examples/pytorch-custom-op-ffi/src/mps_utils.mm
+++ b/examples/pytorch-custom-op-ffi/src/mps_utils.mm
@@ -3,6 +3,41 @@
 #if defined(__APPLE__)
 #import <Metal/Metal.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <torch/mps.h>
+#include <vector>
+
+extern "C" {
+int mfa_rope_rotate_encode_mtl(
+    void* context,
+    void* command_buffer,
+    void* src_buffer, int64_t src_offset,
+    int64_t src_batch_stride, int64_t src_head_stride, int64_t src_seq_stride,
+    void* dst_buffer, int64_t dst_offset,
+    void* cos_buffer, int64_t cos_offset,
+    void* sin_buffer, int64_t sin_offset,
+    int64_t table_batch_stride,
+    bool negate_sin,
+    uint32_t batch_size, uint32_t num_heads, uint32_t seq_len, uint32_t head_dim,
+    const char* precision);
+
+int mfa_attention_encode_mtl(
+    void* context,
+    void* command_buffer,
+    void* q_buffer, int64_t q_offset, const int64_t* q_strides,
+    void* k_buffer, int64_t k_offset, const int64_t* k_strides,
+    void* v_buffer, int64_t v_offset, const int64_t* v_strides,
+    void* out_buffer, int64_t out_offset,
+    void* mask_buffer, int64_t mask_offset,
+    const int64_t* mask_shape,
+    const int64_t* mask_strides,
+    uint32_t mask_ndim,
+    int mask_type,
+    int mask_scalar_type,
+    uint32_t batch_size, uint32_t seq_len_q, uint32_t seq_len_kv,
+    uint32_t num_heads, uint16_t head_dim, float softmax_scale,
+    bool causal,
+    const char* input_precision, const char* intermediate_precision);
+}
 
 namespace metal_sdpa {
 namespace mps_utils {
@@ -23,6 +58,194 @@ void* get_mtl_buffer_handle(const at::Tensor& tensor) {
     return (__bridge void*)buffer;
 }
 
+int encode_rope_rotate_on_torch_stream(
+    void* mfa_context,
+    const at::Tensor& src,
+    const at::Tensor& dst,
+    const at::Tensor& cos_table,
+    const at::Tensor& sin_table,
+    int64_t table_batch_stride,
+    bool negate_sin,
+    uint32_t batch_size,
+    uint32_t num_heads,
+    uint32_t seq_len,
+    uint32_t head_dim,
+    const char* precision) {
+    id<MTLBuffer> src_buf = at::native::mps::getMTLBufferStorage(src);
+    id<MTLBuffer> dst_buf = at::native::mps::getMTLBufferStorage(dst);
+    id<MTLBuffer> cos_buf = at::native::mps::getMTLBufferStorage(cos_table);
+    id<MTLBuffer> sin_buf = at::native::mps::getMTLBufferStorage(sin_table);
+    if (src_buf == nil || dst_buf == nil || cos_buf == nil || sin_buf == nil) {
+        return 1; // MFA_ERROR_INVALID_ARGS
+    }
+
+    auto st = src.strides();
+    __block int rc = 0;
+    @autoreleasepool {
+        at::mps::MPSStream* stream = at::mps::getCurrentMPSStream();
+        if (!stream) {
+            return 5; // MFA_ERROR_EXECUTION_FAILED
+        }
+        dispatch_sync(stream->queue(), ^{
+            stream->endKernelCoalescing();
+            id<MTLCommandBuffer> command_buffer = stream->commandBuffer();
+            if (command_buffer == nil) {
+                rc = 5; // MFA_ERROR_EXECUTION_FAILED
+                return;
+            }
+            // No commit here: the caller encodes attention onto the same
+            // command buffer right after, then commits once.
+            rc = mfa_rope_rotate_encode_mtl(
+                mfa_context,
+                (__bridge void*)command_buffer,
+                (__bridge void*)src_buf, src.storage_offset() * src.element_size(),
+                st[0], st[1], st[2],
+                (__bridge void*)dst_buf, dst.storage_offset() * dst.element_size(),
+                (__bridge void*)cos_buf, cos_table.storage_offset() * cos_table.element_size(),
+                (__bridge void*)sin_buf, sin_table.storage_offset() * sin_table.element_size(),
+                table_batch_stride,
+                negate_sin,
+                batch_size, num_heads, seq_len, head_dim,
+                precision);
+        });
+    }
+    return rc;
+}
+
+int encode_attention_on_torch_stream(
+    void* mfa_context,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& out,
+    const at::Tensor* mask,
+    int mask_type,
+    int mask_scalar_type,
+    uint32_t batch_size,
+    uint32_t seq_len_q,
+    uint32_t seq_len_kv,
+    uint32_t num_heads,
+    uint16_t head_dim,
+    float softmax_scale,
+    bool is_causal,
+    const char* input_precision,
+    const char* intermediate_precision) {
+    id<MTLBuffer> q_buf = at::native::mps::getMTLBufferStorage(q);
+    id<MTLBuffer> k_buf = at::native::mps::getMTLBufferStorage(k);
+    id<MTLBuffer> v_buf = at::native::mps::getMTLBufferStorage(v);
+    id<MTLBuffer> out_buf = at::native::mps::getMTLBufferStorage(out);
+    if (q_buf == nil || k_buf == nil || v_buf == nil || out_buf == nil) {
+        return 1; // MFA_ERROR_INVALID_ARGS
+    }
+
+    const int64_t q_off = q.storage_offset() * q.element_size();
+    const int64_t k_off = k.storage_offset() * k.element_size();
+    const int64_t v_off = v.storage_offset() * v.element_size();
+    const int64_t out_off = out.storage_offset() * out.element_size();
+
+    // Element strides in BHSD order for non-contiguous views (the kernel
+    // requires a contiguous last dim; the caller guarantees that). Null for
+    // contiguous tensors selects the kernel's dense addressing.
+    int64_t q_strides[4], k_strides[4], v_strides[4];
+    auto fill_strides = [](const at::Tensor& t, int64_t* dst) -> const int64_t* {
+        if (t.is_contiguous()) {
+            return nullptr;
+        }
+        auto st = t.strides();
+        for (int i = 0; i < 4; ++i) {
+            dst[i] = st[i];
+        }
+        return dst;
+    };
+    const int64_t* q_strides_ptr = fill_strides(q, q_strides);
+    const int64_t* k_strides_ptr = fill_strides(k, k_strides);
+    const int64_t* v_strides_ptr = fill_strides(v, v_strides);
+
+    id<MTLBuffer> mask_buf = nil;
+    int64_t mask_off = 0;
+    std::vector<int64_t> mask_shape_vec;
+    std::vector<int64_t> mask_stride_vec;
+    uint32_t mask_ndim = 0;
+    if (mask && mask->defined() && mask_type != 0) {
+        mask_buf = at::native::mps::getMTLBufferStorage(*mask);
+        if (mask_buf == nil) {
+            return 1; // MFA_ERROR_INVALID_ARGS
+        }
+        mask_off = mask->storage_offset() * mask->element_size();
+        auto sizes = mask->sizes();
+        auto strides = mask->strides();
+        mask_shape_vec.assign(sizes.begin(), sizes.end());
+        mask_stride_vec.assign(strides.begin(), strides.end());
+        mask_ndim = static_cast<uint32_t>(mask_shape_vec.size());
+    } else {
+        mask_type = 0;
+        mask_scalar_type = 0;
+    }
+
+    __block int rc = 0;
+    @autoreleasepool {
+        at::mps::MPSStream* stream = at::mps::getCurrentMPSStream();
+        if (!stream) {
+            return 5; // MFA_ERROR_EXECUTION_FAILED
+        }
+        // Debug aid: MFA_INSTREAM_ENTRY_SYNC=1 drains the stream before
+        // encoding to distinguish producer-ordering races from encode bugs.
+        static const bool debug_entry_sync = []() {
+            const char* env = std::getenv("MFA_INSTREAM_ENTRY_SYNC");
+            return env && env[0] == '1';
+        }();
+        if (debug_entry_sync) {
+            torch::mps::synchronize();
+        }
+        // Encoding must be serialized against the MPS backend's own encodes.
+        dispatch_sync(stream->queue(), ^{
+            // Close the stream's coalesced eager-kernel encoder (if open) so
+            // our encoder gets its own pass, properly ordered after pending
+            // eager ops. Torch's MPS buffers are hazard-untracked; encoder
+            // boundaries on the stream's command buffer provide the ordering.
+            stream->endKernelCoalescing();
+            id<MTLCommandBuffer> command_buffer = stream->commandBuffer();
+            if (command_buffer == nil) {
+                rc = 5; // MFA_ERROR_EXECUTION_FAILED
+                return;
+            }
+            rc = mfa_attention_encode_mtl(
+                mfa_context,
+                (__bridge void*)command_buffer,
+                (__bridge void*)q_buf, q_off, q_strides_ptr,
+                (__bridge void*)k_buf, k_off, k_strides_ptr,
+                (__bridge void*)v_buf, v_off, v_strides_ptr,
+                (__bridge void*)out_buf, out_off,
+                mask_buf ? (__bridge void*)mask_buf : nullptr,
+                mask_off,
+                mask_shape_vec.empty() ? nullptr : mask_shape_vec.data(),
+                mask_stride_vec.empty() ? nullptr : mask_stride_vec.data(),
+                mask_ndim,
+                mask_type,
+                mask_scalar_type,
+                batch_size, seq_len_q, seq_len_kv,
+                num_heads, head_dim, softmax_scale,
+                is_causal,
+                input_precision, intermediate_precision);
+        });
+        if (rc == 0) {
+            // Submit without waiting; later torch ops on the stream stay
+            // ordered after this kernel.
+            torch::mps::commit();
+            // Debug aid: MFA_INSTREAM_SYNC=1 fully synchronizes after every
+            // encode to distinguish overlap hazards from encode bugs.
+            static const bool debug_sync = []() {
+                const char* env = std::getenv("MFA_INSTREAM_SYNC");
+                return env && env[0] == '1';
+            }();
+            if (debug_sync) {
+                torch::mps::synchronize();
+            }
+        }
+    }
+    return rc;
+}
+
 } // namespace mps_utils
 } // namespace metal_sdpa
 
@@ -37,6 +260,21 @@ bool is_mps_tensor(const at::Tensor&) {
 
 void* get_mtl_buffer_handle(const at::Tensor&) {
     return nullptr;
+}
+
+int encode_rope_rotate_on_torch_stream(
+    void*, const at::Tensor&, const at::Tensor&, const at::Tensor&,
+    const at::Tensor&, int64_t, bool, uint32_t, uint32_t, uint32_t, uint32_t,
+    const char*) {
+    return 3; // MFA_ERROR_DEVICE_NOT_SUPPORTED
+}
+
+int encode_attention_on_torch_stream(
+    void*, const at::Tensor&, const at::Tensor&, const at::Tensor&,
+    const at::Tensor&, const at::Tensor*, int, int,
+    uint32_t, uint32_t, uint32_t, uint32_t, uint16_t, float, bool,
+    const char*, const char*) {
+    return 3; // MFA_ERROR_DEVICE_NOT_SUPPORTED
 }
 
 } // namespace mps_utils

--- a/examples/pytorch-custom-op-ffi/src/python_bindings.cpp
+++ b/examples/pytorch-custom-op-ffi/src/python_bindings.cpp
@@ -26,7 +26,8 @@ namespace metal_sdpa {
         bool is_causal,
         double scale,
         int64_t target_precision,
-        int64_t quant_mode);
+        int64_t quant_mode,
+        c10::optional<torch::Tensor> attn_mask = c10::nullopt);
     void hadamard_rotate_inplace(torch::Tensor tensor, int64_t block_size);
     void set_quantization_mode(int64_t precision, int64_t block_mode);
     void clear_quantization_mode();
@@ -77,7 +78,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           py::arg("is_causal") = false,
           py::arg("scale") = 0.0,
           py::arg("target_precision") = 3,  // 3=INT8, 4=INT4
-          py::arg("quant_mode") = 0);       // 0=tensorWise, 2=blockwise
+          py::arg("quant_mode") = 0,        // 0=tensorWise, 2=blockwise
+          py::arg("attn_mask") = py::none());
 
     m.def("set_quantization_mode",
           &metal_sdpa::set_quantization_mode,

--- a/examples/pytorch-custom-op-ffi/src/python_bindings.cpp
+++ b/examples/pytorch-custom-op-ffi/src/python_bindings.cpp
@@ -60,6 +60,20 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           py::arg("scale") = py::none(),
           py::arg("enable_gqa") = false);
 
+    m.def("rope_scaled_dot_product_attention",
+          &metal_sdpa::MetalSDPABackend::rope_scaled_dot_product_attention,
+          "Fused RoPE + SDPA (interleaved-pair rotation, pair-duplicated fp32 "
+          "cos/sin tables [S,D], [1,S,D] or [B,S,D]; BHSD tensors). "
+          "Gradient callers fall back to eager rotation + the normal path.",
+          py::arg("query"),
+          py::arg("key"),
+          py::arg("value"),
+          py::arg("rope_cos"),
+          py::arg("rope_sin"),
+          py::arg("attn_mask") = py::none(),
+          py::arg("is_causal") = false,
+          py::arg("scale") = py::none());
+
     m.def("metal_flash_attention_autograd",
           &metal_sdpa::metal_flash_attention_autograd,
           "Metal Flash Attention with autograd (forward + backward support)",

--- a/examples/pytorch-custom-op-ffi/src/python_bindings.cpp
+++ b/examples/pytorch-custom-op-ffi/src/python_bindings.cpp
@@ -27,6 +27,9 @@ namespace metal_sdpa {
         double scale,
         int64_t target_precision,
         int64_t quant_mode);
+    void hadamard_rotate_inplace(torch::Tensor tensor, int64_t block_size);
+    void set_quantization_mode(int64_t precision, int64_t block_mode);
+    void clear_quantization_mode();
 }
 
 namespace py = pybind11;
@@ -73,6 +76,16 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           py::arg("scale") = 0.0,
           py::arg("target_precision") = 3,  // 3=INT8, 4=INT4
           py::arg("quant_mode") = 0);       // 0=tensorWise, 2=blockwise
+
+    m.def("set_quantization_mode",
+          &metal_sdpa::set_quantization_mode,
+          "Activate INT8/INT4 quantization for all F.scaled_dot_product_attention calls",
+          py::arg("precision"),   // 3=INT8, 4=INT4
+          py::arg("block_mode")); // 0=tensorWise, 2=blockwise
+
+    m.def("clear_quantization_mode",
+          &metal_sdpa::clear_quantization_mode,
+          "Disable quantization — revert to FP32 attention");
 
     m.def("hadamard_rotate",
           &metal_sdpa::hadamard_rotate_inplace,

--- a/examples/pytorch-custom-op-ffi/src/python_bindings.cpp
+++ b/examples/pytorch-custom-op-ffi/src/python_bindings.cpp
@@ -30,6 +30,8 @@ namespace metal_sdpa {
     void hadamard_rotate_inplace(torch::Tensor tensor, int64_t block_size);
     void set_quantization_mode(int64_t precision, int64_t block_mode);
     void clear_quantization_mode();
+    std::map<std::string, int64_t> get_dispatch_stats();
+    void reset_dispatch_stats();
 }
 
 namespace py = pybind11;
@@ -80,12 +82,29 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("set_quantization_mode",
           &metal_sdpa::set_quantization_mode,
           "Activate INT8/INT4 quantization for all F.scaled_dot_product_attention calls",
-          py::arg("precision"),   // 3=INT8, 4=INT4
-          py::arg("block_mode")); // 0=tensorWise, 2=blockwise
+          py::arg("precision"),   // QUANT_INT8 or QUANT_INT4
+          py::arg("block_mode")); // QUANT_TENSOR_WISE or QUANT_BLOCK_WISE
 
     m.def("clear_quantization_mode",
           &metal_sdpa::clear_quantization_mode,
           "Disable quantization — revert to FP32 attention");
+
+    m.def("get_dispatch_stats",
+          &metal_sdpa::get_dispatch_stats,
+          "Return dispatch counters showing which attention path each call took");
+
+    m.def("reset_dispatch_stats",
+          &metal_sdpa::reset_dispatch_stats,
+          "Reset all dispatch counters to zero");
+
+    // ---- Constants for quantization configuration ----
+    // Import these and pass to set_quantization_mode():
+    //   ext.set_quantization_mode(ext.QUANT_INT8, ext.QUANT_BLOCK_WISE)
+    m.attr("QUANT_NONE")         = static_cast<int64_t>(metal_sdpa::MetalSDPABackend::QUANT_NONE);
+    m.attr("QUANT_INT8")         = static_cast<int64_t>(metal_sdpa::MetalSDPABackend::QUANT_INT8);
+    m.attr("QUANT_INT4")         = static_cast<int64_t>(metal_sdpa::MetalSDPABackend::QUANT_INT4);
+    m.attr("QUANT_TENSOR_WISE")  = static_cast<int64_t>(metal_sdpa::MetalSDPABackend::QUANT_TENSOR_WISE);
+    m.attr("QUANT_BLOCK_WISE")   = static_cast<int64_t>(metal_sdpa::MetalSDPABackend::QUANT_BLOCK_WISE);
 
     m.def("hadamard_rotate",
           &metal_sdpa::hadamard_rotate_inplace,

--- a/examples/zimage/zimage_turbo.py
+++ b/examples/zimage/zimage_turbo.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Z-Image Turbo on Universal Metal Flash Attention.
+
+Generates an image with TONGYI-MAI/Z-Image-Turbo (8 steps by default) on MPS.
+Importing the Metal SDPA extension installs a process-wide ATen override for
+scaled_dot_product_attention on MPS, so the transformer's attention runs
+through UMFA without any monkeypatching. Pass --native to skip the extension
+and run PyTorch's native MPS SDPA instead.
+"""
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _prepend_dyld_library_path(paths) -> None:
+    existing = os.environ.get("DYLD_LIBRARY_PATH", "")
+    valid = [str(path) for path in paths if path.exists()]
+    if not valid:
+        return
+    prefix = ":".join(valid)
+    os.environ["DYLD_LIBRARY_PATH"] = f"{prefix}:{existing}" if existing else prefix
+
+
+_prepend_dyld_library_path(
+    [
+        PROJECT_ROOT / ".build" / "arm64-apple-macosx" / "release",
+        PROJECT_ROOT / ".build" / "arm64-apple-macosx" / "debug",
+    ]
+)
+
+
+def _maybe_add_venv_site_packages() -> None:
+    venv_root = Path(os.environ.get("VIRTUAL_ENV", PROJECT_ROOT / ".venv"))
+    if not venv_root.exists():
+        return
+    for site_packages in venv_root.glob("lib/python*/site-packages"):
+        if site_packages.is_dir():
+            sys.path.insert(0, str(site_packages))
+            break
+
+
+_maybe_add_venv_site_packages()
+
+# Freshly built extension takes precedence over any stale installed copy
+sys.path.insert(0, str(PROJECT_ROOT / "examples" / "pytorch-custom-op-ffi"))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Z-Image Turbo via Metal SDPA")
+    parser.add_argument(
+        "--model", default="TONGYI-MAI/Z-Image-Turbo", help="Model id or local path"
+    )
+    parser.add_argument(
+        "--prompt",
+        default="a photo of a corgi wearing sunglasses on a beach",
+        help="Prompt used for generation",
+    )
+    parser.add_argument("--steps", type=int, default=8, help="Inference steps")
+    parser.add_argument("--height", type=int, default=1024, help="Image height")
+    parser.add_argument("--width", type=int, default=1024, help="Image width")
+    parser.add_argument(
+        "--guidance-scale",
+        type=float,
+        default=0.0,
+        help="CFG scale. ZImagePipeline enables CFG when guidance_scale > 0; "
+        "Turbo is guidance-distilled, so 0.0 (no CFG) is correct",
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument(
+        "--native",
+        action="store_true",
+        help="Skip the Metal SDPA extension and use PyTorch's native MPS SDPA",
+    )
+    parser.add_argument(
+        "--local-files-only",
+        action="store_true",
+        help="Load from the local Hugging Face cache without network access",
+    )
+    parser.add_argument("--output", default=None, help="Output PNG path")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    import torch
+
+    metal_ext = None
+    if args.native:
+        print("🐍 Native mode: Metal SDPA extension NOT loaded")
+    else:
+        import metal_sdpa_extension as metal_ext
+
+        print(
+            f"✅ Metal SDPA extension loaded (v{metal_ext.get_version()}) - "
+            "ATen MPS override active"
+        )
+
+    from diffusers import ZImagePipeline
+
+    print("📦 Loading Z-Image Turbo pipeline...")
+    load_start = time.time()
+    pipe = ZImagePipeline.from_pretrained(
+        args.model,
+        torch_dtype=torch.bfloat16,
+        local_files_only=args.local_files_only,
+    ).to("mps")
+    print(f"📦 Pipeline loaded in {time.time() - load_start:.1f}s")
+
+    if metal_ext is not None:
+        metal_ext.reset_dispatch_stats()
+
+    print(
+        f"🎨 Generating {args.width}x{args.height}, {args.steps} steps, "
+        f"guidance {args.guidance_scale}..."
+    )
+    start = time.time()
+    with torch.inference_mode():
+        image = pipe(
+            prompt=args.prompt,
+            num_inference_steps=args.steps,
+            height=args.height,
+            width=args.width,
+            guidance_scale=args.guidance_scale,
+            generator=torch.Generator().manual_seed(args.seed),
+        ).images[0]
+    elapsed = time.time() - start
+
+    if args.output:
+        out_path = Path(args.output)
+    else:
+        out_dir = PROJECT_ROOT / "examples" / "zimage" / "output"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        suffix = "native" if args.native else "umfa"
+        out_path = out_dir / f"zimage_turbo_{suffix}_{args.steps}step.png"
+    image.save(out_path)
+
+    print(f"✅ Generated in {elapsed:.2f}s -> {out_path}")
+
+    if metal_ext is not None:
+        stats = metal_ext.get_dispatch_stats()
+        print(f"📊 UMFA dispatch stats: {stats}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces several improvements and API changes to the quantized multi-head attention (MFA) bridge and its FFI, focusing on enhanced mask handling, more precise buffer management, and improved test coverage for input precision. The main changes include new support for mask buffers in quantized forward and backward passes, updates to the FFI to expose a lower-level Metal command buffer encoding API, and stricter enforcement of input precision in tests.

### Quantized Attention API and Implementation Improvements

* Added support for an optional mask buffer in quantized forward (`mfa_quantized_forward_with_lse`) and backward (`mfa_quantized_backward`) passes, including buffer offset calculations and passing mask data to the underlying attention kernels. [[1]](diffhunk://#diff-2c0be8278f040a7003b60d636b04a393073d83b5d40226f74f44dd1f53a61de1R235) [[2]](diffhunk://#diff-2c0be8278f040a7003b60d636b04a393073d83b5d40226f74f44dd1f53a61de1L255-R264) [[3]](diffhunk://#diff-2c0be8278f040a7003b60d636b04a393073d83b5d40226f74f44dd1f53a61de1L312-R340) [[4]](diffhunk://#diff-2c0be8278f040a7003b60d636b04a393073d83b5d40226f74f44dd1f53a61de1R375) [[5]](diffhunk://#diff-2c0be8278f040a7003b60d636b04a393073d83b5d40226f74f44dd1f53a61de1R409-R411) [[6]](diffhunk://#diff-2c0be8278f040a7003b60d636b04a393073d83b5d40226f74f44dd1f53a61de1L447-R487) [[7]](diffhunk://#diff-2c0be8278f040a7003b60d636b04a393073d83b5d40226f74f44dd1f53a61de1L479-R505) [[8]](diffhunk://#diff-2c0be8278f040a7003b60d636b04a393073d83b5d40226f74f44dd1f53a61de1L512-R535)
* Improved quantized element size calculation to account for packed INT4 data (0.5 bytes/value) and clarified buffer offset math for all quantized precisions. [[1]](diffhunk://#diff-2c0be8278f040a7003b60d636b04a393073d83b5d40226f74f44dd1f53a61de1L312-R340) [[2]](diffhunk://#diff-2c0be8278f040a7003b60d636b04a393073d83b5d40226f74f44dd1f53a61de1L447-R487)

### FFI (C header) API Additions and Changes

* Introduced a new `mfa_attention_encode_mtl` FFI function for encoding attention directly into a caller-provided Metal command buffer, enabling integration with external streams (e.g., PyTorch MPS). [[1]](diffhunk://#diff-254400c3acb5456b6401da64d493cba823a089ac84fd4516ec5d19974b6bcf87R255-R287) [[2]](diffhunk://#diff-0995af602c54c534a03e5c228012add83814d6de4d9a3f0e1aedf12c14b86ebcR302-R335)
* Updated the FFI for the backward pass to require a scratch buffer and removed the unused `output_precision` argument. [[1]](diffhunk://#diff-254400c3acb5456b6401da64d493cba823a089ac84fd4516ec5d19974b6bcf87R302) [[2]](diffhunk://#diff-254400c3acb5456b6401da64d493cba823a089ac84fd4516ec5d19974b6bcf87L281) [[3]](diffhunk://#diff-0995af602c54c534a03e5c228012add83814d6de4d9a3f0e1aedf12c14b86ebcR420) [[4]](diffhunk://#diff-0995af602c54c534a03e5c228012add83814d6de4d9a3f0e1aedf12c14b86ebcL398)

### Testing and Input Precision Handling

* Tests now strictly encode input data into the memory format specified by the precision label (FP16, BF16, FP32), ensuring that the kernel receives data in the correct format and preventing misinterpretation of input buffers. [[1]](diffhunk://#diff-ecadea72c71a3299c0594b89345d82e0cf2984662b2e13d8031deee2e9a1876bL167-R176) [[2]](diffhunk://#diff-ecadea72c71a3299c0594b89345d82e0cf2984662b2e13d8031deee2e9a1876bL178-R199) [[3]](diffhunk://#diff-ecadea72c71a3299c0594b89345d82e0cf2984662b2e13d8031deee2e9a1876bR603-R636) [[4]](diffhunk://#diff-ecadea72c71a3299c0594b89345d82e0cf2984662b2e13d8031deee2e9a1876bL611-R663) [[5]](diffhunk://#diff-ecadea72c71a3299c0594b89345d82e0cf2984662b2e13d8031deee2e9a1876bL622-R685)

These changes together make the quantized attention interface more robust, flexible, and correct, especially when integrating with external frameworks and when using non-FP32 input data.