### PR TITLE
feat: quantized attention perf overhaul + macOS 26 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ The `metal-flash-attention` directory is a git submodule pointing at
 | `metal-flash-attention/.../AttentionKernel+Source.swift` | Code-generated Metal kernel source (all kernel types) |
 | `metal-flash-attention/.../AttentionKernel+Accumulate.swift` | Outer-product accumulate loop with blockwise dequantize-on-load |
 | `metal-flash-attention/.../GEMMHeaders.swift` | Metal header: simdgroup storage, load_quantized_int8/int4, buffer bindings |
+| `metal-flash-attention/.../MetalLibraryCompiler.swift` | CLI fallback: JIT → `xcrun metal` for macOS 26 `__asm` support |
 | `metal-flash-attention/.../HadamardRotation.swift` | ConvRot-style FWHT kernel for outlier smoothing |
 
 ## Build
@@ -77,6 +78,26 @@ disables `__HAVE_BFLOAT__`. All `device.makeLibrary` calls must use
 `languageVersion = .version3_2`. The `mfaCompileOptions()` helper in
 `MFABridge.swift` and the inline options in `MultiHeadAttention.swift`
 enforce this.
+
+### macOS 26 (Tahoe) rejects `__asm` in runtime JIT
+
+macOS 26's runtime Metal compiler (`device.makeLibrary(source:)`) rejects
+inline `__asm(...)` directives with "illegal string literal in 'asm'". The
+flash-attention codegen emits `__asm` for simdgroup async-copy intrinsics
+(`createMetalSimdgroupEvent()` in `GEMMHeaders.swift`), so runtime JIT
+compilation fails on macOS 26.
+
+The workaround is `MetalLibraryCompiler.makeLibrary(device:source:options:)`
+(`metal-flash-attention/Sources/FlashAttention/MetalLibraryCompiler.swift`):
+it tries the runtime JIT first (fast path — works on macOS 15 and for kernels
+without `__asm`), then transparently falls back to the offline `xcrun metal`
+CLI (`xcrun metal -std=macos-metal3.2 -c src.metal -o src.air` →
+`xcrun metallib src.air -o src.metallib` → `device.makeLibrary(URL:)`),
+which still accepts `__asm`. All production `makeLibrary(source:)` call sites
+route through this helper. Bfloat diagnostic probes
+(`mfa_has_native_bfloat*`) intentionally bypass the helper.
+
+Reference: <https://github.com/imperatormk/metal24-asm-repro>
 
 ### Multi-head buffer binding contract
 

--- a/Sources/MFABridge/MFABridge+Quantized.swift
+++ b/Sources/MFABridge/MFABridge+Quantized.swift
@@ -241,7 +241,8 @@ public func mfa_quantized_forward_with_lse(
   _ softmaxScale: Float,
   _ causal: Bool,
   _ targetPrecision: Int32,
-  _ quantMode: Int32
+  _ quantMode: Int32,
+  _ inputPrecision: Int32
 )
   -> Int32
 {
@@ -269,8 +270,16 @@ public func mfa_quantized_forward_with_lse(
   case 2: .blockwise(blockSizeK: 64)
   default: .tensorWise
   }
+  let inputPrec: GEMMOperandPrecision = switch inputPrecision {
+  case 0: .FP16
+  case 1: .BF16
+  case 2: .FP32
+  default: .FP32
+  }
 
-  let quantAttention = QuantizedAttention(device: mfaContext.device)
+  // Use the cached singleton — recreating QuantizedAttention per call would
+  // destroy the pipeline cache and force kernel recompilation every call.
+  let quantAttention = mfaContext.quantizedAttention
 
   let fullQShape = [Int(batchSize), Int(numHeads), Int(seqLenQ), Int(headDim)]
   let fullKVShape = [Int(batchSize), Int(numHeads), Int(seqLenKV), Int(headDim)]
@@ -278,18 +287,18 @@ public func mfa_quantized_forward_with_lse(
   guard
     let qTensor = quantAttention.createQuantizedTensorFromBufferPublic(
       buffer: qBuffer.buffer, shape: fullQShape,
-      inputPrecision: .FP32, targetPrecision: precision,
-      quantizationMode: mode, targetStrategy: .legacy
+      inputPrecision: inputPrec, targetPrecision: precision,
+      quantizationMode: mode, targetStrategy: .symmetric
     ),
     let kTensor = quantAttention.createQuantizedTensorFromBufferPublic(
       buffer: kBuffer.buffer, shape: fullKVShape,
-      inputPrecision: .FP32, targetPrecision: precision,
-      quantizationMode: mode, targetStrategy: .legacy
+      inputPrecision: inputPrec, targetPrecision: precision,
+      quantizationMode: mode, targetStrategy: .symmetric
     ),
     let vTensor = quantAttention.createQuantizedTensorFromBufferPublic(
       buffer: vBuffer.buffer, shape: fullKVShape,
-      inputPrecision: .FP32, targetPrecision: precision,
-      quantizationMode: mode, targetStrategy: .legacy
+      inputPrecision: inputPrec, targetPrecision: precision,
+      quantizationMode: mode, targetStrategy: .symmetric
     )
   else {
     return 5
@@ -312,44 +321,37 @@ public func mfa_quantized_forward_with_lse(
     baseDescriptor: baseDescriptor, quantizationConfig: quantConfig
   )
 
-  // INT4 data is packed 2 values per byte; INT8 is 1 byte per value.
-  let quantElemBytes = precision == .INT4
-    ? 0.5 // packed: 2 nibbles per byte
-    : Double(precision.size)
-  let fp32Size = MemoryLayout<Float>.stride
-  let maskHeadSize = Int(seqLenQ) * Int(seqLenKV) * fp32Size
+  // Single 3D-grid dispatch covering all heads and batches in parallel
+  // (same pattern as BF16 MultiHeadAttention). Eliminates the per-head
+  // encoder loop.
+  guard let commandBuffer = quantAttention.makeCommandBuffer() else {
+    return 5
+  }
 
-  for batchIdx in 0..<Int(batchSize) {
-    for headIdx in 0..<Int(numHeads) {
-      let headIdxFlat = batchIdx * Int(numHeads) + headIdx
-      let qOff = Int(Double(headIdxFlat) * Double(seqLenQ) * Double(headDim) * quantElemBytes)
-      let kOff = Int(Double(headIdxFlat) * Double(seqLenKV) * Double(headDim) * quantElemBytes)
-      let vOff = kOff
-      let oOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * Int(headDim) * fp32Size
-      let lseOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * fp32Size
-      let maskOff = (batchIdx * Int(numHeads) + headIdx) * maskHeadSize
+  guard
+    quantAttention.forwardMultiHead(
+      query: qTensor, key: kTensor, value: vTensor,
+      output: outBuffer.buffer,
+      descriptor: quantDescriptor,
+      batchSize: batchSize,
+      numHeads: numHeads,
+      numKVHeads: numHeads,
+      seqLenQ: seqLenQ,
+      headDim: headDim,
+      logsumexp: lseBuffer.buffer,
+      mask: maskBuffer?.buffer,
+      into: commandBuffer
+    ) != nil
+  else {
+    return 5
+  }
 
-      guard
-        let cmd = quantAttention.forward(
-          query: qTensor, key: kTensor, value: vTensor,
-          output: outBuffer.buffer,
-          descriptor: quantDescriptor,
-          bufferOffsets: (q: qOff, k: kOff, v: vOff, o: oOff, lse: lseOff),
-          externalLogsumexp: lseBuffer.buffer,
-          mask: maskBuffer?.buffer,
-          maskOffset: maskOff
-        )
-      else {
-        return 5
-      }
-      cmd.commit()
-      cmd.waitUntilCompleted()
+  commandBuffer.commit()
+  commandBuffer.waitUntilCompleted()
 
-      if let error = cmd.error {
-        print("Quantized forward error (batch \(batchIdx), head \(headIdx)): \(error)")
-        return 5
-      }
-    }
+  if let error = commandBuffer.error {
+    print("Quantized forward error: \(error)")
+    return 5
   }
 
   return 0
@@ -381,7 +383,8 @@ public func mfa_quantized_backward(
   _ softmaxScale: Float,
   _ causal: Bool,
   _ targetPrecision: Int32,
-  _ quantMode: Int32
+  _ quantMode: Int32,
+  _ inputPrecision: Int32
 )
   -> Int32
 {
@@ -416,8 +419,15 @@ public func mfa_quantized_backward(
   case 2: .blockwise(blockSizeK: 64)
   default: .tensorWise
   }
+  let inputPrec: GEMMOperandPrecision = switch inputPrecision {
+  case 0: .FP16
+  case 1: .BF16
+  case 2: .FP32
+  default: .FP32
+  }
 
-  let quantAttention = QuantizedAttention(device: mfaContext.device)
+  // Use the cached singleton — see mfa_quantized_forward_with_lse.
+  let quantAttention = mfaContext.quantizedAttention
 
   let fullQShape = [Int(batchSize), Int(numHeads), Int(seqLenQ), Int(headDim)]
   let fullKVShape = [Int(batchSize), Int(numHeads), Int(seqLenKV), Int(headDim)]
@@ -425,18 +435,18 @@ public func mfa_quantized_backward(
   guard
     let qTensor = quantAttention.createQuantizedTensorFromBufferPublic(
       buffer: qBuffer.buffer, shape: fullQShape,
-      inputPrecision: .FP32, targetPrecision: precision,
-      quantizationMode: mode, targetStrategy: .legacy
+      inputPrecision: inputPrec, targetPrecision: precision,
+      quantizationMode: mode, targetStrategy: .symmetric
     ),
     let kTensor = quantAttention.createQuantizedTensorFromBufferPublic(
       buffer: kBuffer.buffer, shape: fullKVShape,
-      inputPrecision: .FP32, targetPrecision: precision,
-      quantizationMode: mode, targetStrategy: .legacy
+      inputPrecision: inputPrec, targetPrecision: precision,
+      quantizationMode: mode, targetStrategy: .symmetric
     ),
     let vTensor = quantAttention.createQuantizedTensorFromBufferPublic(
       buffer: vBuffer.buffer, shape: fullKVShape,
-      inputPrecision: .FP32, targetPrecision: precision,
-      quantizationMode: mode, targetStrategy: .legacy
+      inputPrecision: inputPrec, targetPrecision: precision,
+      quantizationMode: mode, targetStrategy: .symmetric
     )
   else {
     return 5
@@ -459,92 +469,64 @@ public func mfa_quantized_backward(
     baseDescriptor: baseDescriptor, quantizationConfig: quantConfig
   )
 
-  let quantElemBytes = precision == .INT4
-    ? 0.5
-    : Double(precision.size)
   let fp32Size = MemoryLayout<Float>.stride
 
-  // Scratch D buffer — allocated once, reused for all heads.
+  // D buffer sized for ALL heads (each head writes to its own slice).
   let dBuf = device.makeBuffer(
-    length: Int(seqLenQ) * fp32Size,
+    length: Int(seqLenQ) * Int(numHeads) * Int(batchSize) * fp32Size,
     options: .storageModeShared
   )!
 
-  let maskHeadSize = Int(seqLenQ) * Int(seqLenKV) * fp32Size
+  // Two 3D-grid dispatches (backwardQuery + backwardKeyValue) covering all
+  // heads in parallel, replacing the previous B×H×2 per-head loop.
+  guard let commandBuffer = quantAttention.makeCommandBuffer() else {
+    return 5
+  }
 
-  for batchIdx in 0..<Int(batchSize) {
-    for headIdx in 0..<Int(numHeads) {
-      let headIdxFlat = batchIdx * Int(numHeads) + headIdx
-      let qOff = Int(Double(headIdxFlat) * Double(seqLenQ) * Double(headDim) * quantElemBytes)
-      let kOff = Int(Double(headIdxFlat) * Double(seqLenKV) * Double(headDim) * quantElemBytes)
-      let vOff = kOff
-      let oOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * Int(headDim) * fp32Size
-      let goOff = oOff
-      let lseOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenQ) * fp32Size
-      let gqOff = oOff
-      let gkOff = (batchIdx * Int(numHeads) + headIdx) * Int(seqLenKV) * Int(headDim) * fp32Size
-      let gvOff = gkOff
-      let maskOff = (batchIdx * Int(numHeads) + headIdx) * maskHeadSize
+  guard
+    quantAttention.backwardQueryMultiHead(
+      query: qTensor, key: kTensor, value: vTensor,
+      output: outBuffer.buffer,
+      gradOutput: gradOutBuffer.buffer,
+      logsumexp: lseBuffer.buffer,
+      gradQuery: gradQBuffer.buffer,
+      dValues: dBuf,
+      descriptor: quantDescriptor,
+      batchSize: batchSize,
+      numHeads: numHeads,
+      numKVHeads: numHeads,
+      seqLenQ: seqLenQ,
+      headDim: headDim,
+      mask: maskBuffer?.buffer,
+      into: commandBuffer
+    ) != nil
+  else { return 5 }
 
-      guard
-        let cmdBQ = quantAttention.backwardQuery(
-          query: qTensor,
-          key: kTensor,
-          value: vTensor,
-          output: outBuffer.buffer,
-          gradOutput: gradOutBuffer.buffer,
-          logsumexp: lseBuffer.buffer,
-          gradQuery: gradQBuffer.buffer,
-          dValues: dBuf,
-          descriptor: quantDescriptor,
-          bufferOffsets: (
-            q: qOff, k: kOff, v: vOff, o: oOff,
-            go: goOff, lse: lseOff, gq: gqOff, dv: 0
-          ),
-          mask: maskBuffer?.buffer,
-          maskOffset: maskOff
-        )
-      else {
-        return 5
-      }
-      cmdBQ.commit()
-      cmdBQ.waitUntilCompleted()
+  guard
+    quantAttention.backwardKeyValueMultiHead(
+      query: qTensor, key: kTensor, value: vTensor,
+      gradOutput: gradOutBuffer.buffer,
+      logsumexp: lseBuffer.buffer,
+      dValues: dBuf,
+      gradKey: gradKBuffer.buffer,
+      gradValue: gradVBuffer.buffer,
+      descriptor: quantDescriptor,
+      batchSize: batchSize,
+      numHeads: numHeads,
+      numKVHeads: numHeads,
+      seqLenKV: seqLenKV,
+      headDim: headDim,
+      mask: maskBuffer?.buffer,
+      into: commandBuffer
+    ) != nil
+  else { return 5 }
 
-      if let error = cmdBQ.error {
-        print("Quantized backwardQuery error: \(error)")
-        return 5
-      }
+  commandBuffer.commit()
+  commandBuffer.waitUntilCompleted()
 
-      guard
-        let cmdBK = quantAttention.backwardKeyValue(
-          query: qTensor,
-          key: kTensor,
-          value: vTensor,
-          gradOutput: gradOutBuffer.buffer,
-          logsumexp: lseBuffer.buffer,
-          dValues: dBuf,
-          gradKey: gradKBuffer.buffer,
-          gradValue: gradVBuffer.buffer,
-          descriptor: quantDescriptor,
-          bufferOffsets: (
-            q: qOff, k: kOff, v: vOff,
-            go: goOff, lse: lseOff, dv: 0,
-            gk: gkOff, gv: gvOff
-          ),
-          mask: maskBuffer?.buffer,
-          maskOffset: maskOff
-        )
-      else {
-        return 5
-      }
-      cmdBK.commit()
-      cmdBK.waitUntilCompleted()
-
-      if let error = cmdBK.error {
-        print("Quantized backwardKeyValue error: \(error)")
-        return 5
-      }
-    }
+  if let error = commandBuffer.error {
+    print("Quantized backward error: \(error)")
+    return 5
   }
 
   return 0

--- a/Sources/MFABridge/MFABridge.swift
+++ b/Sources/MFABridge/MFABridge.swift
@@ -328,7 +328,9 @@ final class MFAContext {
       do {
         let opts = MTLCompileOptions()
         opts.languageVersion = .version3_2
-        let library = try device.makeLibrary(source: Self.ropeKernelSource, options: opts)
+        let library = try MetalLibraryCompiler.makeLibrary(
+          device: device, source: Self.ropeKernelSource, options: opts
+        )
         guard let function = library.makeFunction(name: functionName) else {
           return nil
         }
@@ -348,8 +350,8 @@ final class MFAContext {
     }
 
     do {
-      let library = try device.makeLibrary(
-        source: Self.maskKernelSource,
+      let library = try MetalLibraryCompiler.makeLibrary(
+        device: device, source: Self.maskKernelSource,
         options: mfaCompileOptions()
       )
       guard let function = library.makeFunction(name: "mfa_prepare_mask") else {
@@ -1251,7 +1253,10 @@ public func mfa_attention_forward(
 
       // Get the Metal function using native kernel source (no string replacement!)
       let source = kernel.createSource()
-      let library = try mfaContext.device.makeLibrary(source: source, options: mfaCompileOptions())
+      let library = try MetalLibraryCompiler.makeLibrary(
+        device: mfaContext.device, source: source,
+        options: mfaCompileOptions()
+      )
       let function = try library.makeFunction(name: "attention", constantValues: constants)
 
       // Create pipeline descriptor with proper settings for Apple Silicon
@@ -2596,7 +2601,9 @@ private func dequantizeBuffer(
   let compileOptions = mfaCompileOptions(mathSafe: true)
 
   guard
-    let library = try? device.makeLibrary(source: kernelSource, options: compileOptions),
+    let library = try? MetalLibraryCompiler.makeLibrary(
+      device: device, source: kernelSource, options: compileOptions
+    ),
     let function = library.makeFunction(name: "dequantize_int8_to_fp16"),
     let pipeline = try? device.makeComputePipelineState(function: function)
   else {

--- a/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
+++ b/examples/pytorch-custom-op-ffi/include/metal_sdpa_backend.h
@@ -514,7 +514,8 @@ extern "C" {
         uint32_t batch_size, uint32_t seq_len_q, uint32_t seq_len_kv,
         uint32_t num_heads, uint16_t head_dim,
         float softmax_scale, bool causal,
-        int32_t target_precision, int32_t quant_mode);
+        int32_t target_precision, int32_t quant_mode,
+        int32_t input_precision);
 
     // Backward: re-quantizes Q/K/V, runs quantized flash backward.
     int32_t mfa_quantized_backward(
@@ -526,7 +527,8 @@ extern "C" {
         uint32_t batch_size, uint32_t seq_len_q, uint32_t seq_len_kv,
         uint32_t num_heads, uint16_t head_dim,
         float softmax_scale, bool causal,
-        int32_t target_precision, int32_t quant_mode);
+        int32_t target_precision, int32_t quant_mode,
+        int32_t input_precision);
 
     // =============================================================================
     // Multi-Latent Attention (MLA) Support

--- a/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
+++ b/examples/pytorch-custom-op-ffi/src/metal_sdpa_backend.cpp
@@ -3152,10 +3152,26 @@ public:
       throw std::runtime_error("Metal SDPA backend not initialized");
     }
 
-    // Promote to fp32 — the quantization kernel reads FP32 input.
-    query = query.to(torch::kFloat32).contiguous();
-    key = key.to(torch::kFloat32).contiguous();
-    value = value.to(torch::kFloat32).contiguous();
+    // Detect input precision — avoid FP32 promotion to save memory.
+    // The Swift quantization path handles FP16/BF16/FP32 natively.
+    int32_t input_prec;
+    auto q_dtype = query.scalar_type();
+    if (q_dtype == torch::kHalf) {
+        input_prec = 0; // FP16
+    } else if (q_dtype == torch::kBFloat16) {
+        input_prec = 1; // BF16
+    } else {
+        // Non-floating-point or already FP32: promote to FP32 for safety.
+        if (q_dtype != torch::kFloat32) {
+            query = query.to(torch::kFloat32);
+            key = key.to(torch::kFloat32);
+            value = value.to(torch::kFloat32);
+        }
+        input_prec = 2; // FP32
+    }
+    query = query.contiguous();
+    key = key.contiguous();
+    value = value.contiguous();
     if (query.device().type() == at::kMPS) {
       torch::mps::synchronize();
     }
@@ -3172,7 +3188,10 @@ public:
       sm_scale = 1.0f / std::sqrt(static_cast<float>(dim));
     }
 
-    auto output = torch::empty_like(query);
+    // Output is always FP32 (the quantized kernel accumulates in FP32).
+    auto output = torch::empty(
+        {batch, heads, seq_q, dim},
+        torch::dtype(torch::kFloat32).device(query.device()));
     auto lse = torch::empty(
         {batch * heads * seq_q}, torch::kFloat32).to(query.device());
 
@@ -3217,7 +3236,8 @@ public:
         batch, seq_q, seq_kv, heads, dim,
         sm_scale, is_causal,
         static_cast<int32_t>(target_precision),
-        static_cast<int32_t>(quant_mode));
+        static_cast<int32_t>(quant_mode),
+        input_prec);
 
     mfa_destroy_buffer(q_b);
     mfa_destroy_buffer(k_b);
@@ -3238,6 +3258,7 @@ public:
     ctx->saved_data["is_causal"] = is_causal;
     ctx->saved_data["target_precision"] = target_precision;
     ctx->saved_data["quant_mode"] = quant_mode;
+    ctx->saved_data["input_precision"] = static_cast<int64_t>(input_prec);
     if (mask_tensor.defined()) {
         ctx->saved_data["mask"] = mask_tensor;
     }
@@ -3259,6 +3280,9 @@ public:
     bool is_causal = ctx->saved_data["is_causal"].toBool();
     int64_t target_precision = ctx->saved_data["target_precision"].toInt();
     int64_t quant_mode = ctx->saved_data["quant_mode"].toInt();
+    int64_t input_prec = ctx->saved_data.count("input_precision")
+                             ? ctx->saved_data["input_precision"].toInt()
+                             : 2; // default FP32
     torch::Tensor mask_tensor;
     if (ctx->saved_data.count("mask") && ctx->saved_data["mask"].isTensor()) {
         mask_tensor = ctx->saved_data["mask"].toTensor();
@@ -3275,9 +3299,11 @@ public:
 
     auto mfa_ctx = MetalSDPABackend::get_swift_context();
     auto output_fp32 = saved[3];
-    auto d_query = torch::zeros_like(query);
-    auto d_key = torch::zeros_like(key);
-    auto d_value = torch::zeros_like(value);
+    // Gradient buffers are FP32 — the backward kernel writes FP32 data.
+    auto fp32_opts = torch::dtype(torch::kFloat32).device(query.device());
+    auto d_query = torch::zeros(query.sizes(), fp32_opts);
+    auto d_key = torch::zeros(key.sizes(), fp32_opts);
+    auto d_value = torch::zeros(value.sizes(), fp32_opts);
 
     // Synchronize AFTER zeros_like (which schedules MPS zero-fill) but BEFORE
     // the FFI writes. Without this, the MPS zero-fill can execute after the
@@ -3318,7 +3344,8 @@ public:
         batch, seq_q, seq_kv, heads, dim,
         sm_scale, is_causal,
         static_cast<int32_t>(target_precision),
-        static_cast<int32_t>(quant_mode));
+        static_cast<int32_t>(quant_mode),
+        static_cast<int32_t>(input_prec));
 
     mfa_destroy_buffer(q_b);
     mfa_destroy_buffer(k_b);
@@ -3335,6 +3362,17 @@ public:
       throw std::runtime_error(
           "Quantized flash attention backward failed with code " +
           std::to_string(result));
+    }
+
+    // Cast gradients back to the original input dtype for autograd.
+    if (input_prec == 0) { // FP16
+      d_query = d_query.to(torch::kHalf);
+      d_key = d_key.to(torch::kHalf);
+      d_value = d_value.to(torch::kHalf);
+    } else if (input_prec == 1) { // BF16
+      d_query = d_query.to(torch::kBFloat16);
+      d_key = d_key.to(torch::kBFloat16);
+      d_value = d_value.to(torch::kBFloat16);
     }
 
     return {d_query, d_key, d_value,


### PR DESCRIPTION
Update metal-flash-attention submodule pointer (bghira/metal-flash-attention-plus#17).

Quantized attention forward/backward was 10-25x slower than BF16 due to five compounding issues, now all fixed:

- Use cached QuantizedAttention singleton instead of recreating per FFI call (was destroying the pipeline cache, forcing kernel recompilation every forward/backward)
- Replace per-head dispatch loop (24-48 separate encoders) with single 3D-grid dispatch via forwardMultiHead/backwardQueryMultiHead
- Route quantization through GPU tensor-wise kernels (quantizeTensorWise) instead of CPU scalar convertBufferToFloat + scan + quantize
- Stop forcing FP32 promotion of Q/K/V in the C++ autograd path; pass native input precision through a new input_precision FFI parameter
- Cache GEMMRuntimeQuantization init failure to prevent per-call retry

Route all production makeLibrary(source:) calls through MetalLibraryCompiler (JIT fast path, xcrun metal CLI fallback for macOS 26 __asm support).

Performance (768x512 49f LTX synthetic block):
  INT8 forward:  2950ms -> 127ms  (23x)
  INT4 forward:  2800ms -> 112ms  (25x)
  INT8 backward: ~2950ms -> 307ms  (9.6x)
  INT4 backward: ~2800ms -> 262ms  (10.7x)
  INT8 peak driver: ~33.2 GiB -> ~26.3 GiB